### PR TITLE
Compilation fail for older git version: Fix copyright year detection

### DIFF
--- a/etc/configure.cmake
+++ b/etc/configure.cmake
@@ -34,7 +34,7 @@ endif()
 if(GIT_SHA1)
   # Get a single list of copyright years for changes made to SRecord
   execute_process(
-    COMMAND "${GIT_EXECUTABLE}" log --reverse --date=format:%Y --pretty=format:%as
+    COMMAND "${GIT_EXECUTABLE}" log --reverse --date=format:%Y --pretty=format:%ad
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
     OUTPUT_VARIABLE DATES
     ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
Compilation of `versn_stamp.cc` failed, because `COPYRIGHT_YEARS` was not defined in `patchlevel.h`.

This was caused by git v2.20.1, which does not yet support `%as`.
So that git version repeated the string `%as` instead of the year numbers.

The default from the else branch was not set, because the commit has had been correctly evaluated.