### PR TITLE
Add configuration for Editorconfig and fix tabs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+max_line_length = 80
+tab_width = 8
+trim_trailing_whitespace = true
+
+[*.cmake,CMakeLists.txt]
+indent_size = 2
+tab_width = 2
+
+[COMMIT_EDITMSG]
+max_line_length = 72

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -197,11 +197,11 @@ if(NOT WIN32)
   foreach(i ${sections})
     install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/man${i}/
             DESTINATION ${CMAKE_INSTALL_MANDIR}/man${i}
-	    FILES_MATCHING PATTERN "*.${i}")
+            FILES_MATCHING PATTERN "*.${i}")
   endforeach()
 endif()
 
 # Install the website
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html/
         DESTINATION ${CMAKE_INSTALL_DOCDIR}/htdocs
- 	COMPONENT website)
+        COMPONENT website)

--- a/doc/etc/BUILDING.man
+++ b/doc/etc/BUILDING.man
@@ -397,4 +397,3 @@ l r l.
 Scott Finneran;E\[hy]Mail:;scottfinneran@yahoo.com.au
 Peter Miller;E\[hy]Mail:;pmiller@opensource.org.au
 .TE
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/README.man
+++ b/doc/etc/README.man
@@ -418,4 +418,3 @@ releases.  For excruciating and complete detail, and also credits for
 those of you who have generously sent me suggestions and bug reports,
 see the \f[I]/doc/etc/CHANGES.*\fP files.
 .so etc/new.so
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/coding-style.so
+++ b/doc/etc/coding-style.so
@@ -70,4 +70,3 @@ written, it has value to you; the issue of freeloaders is irrelevant.
 .PP
 Conversely, integrating complete open source contributions and patches
 is done \f[I]gratis\fP, and usually done as promptly as time permits.
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new-file-format.so
+++ b/doc/etc/new-file-format.so
@@ -265,4 +265,3 @@ l l l.
 Scott Finneran;E\[hy]Mail:;scottfinneran@yahoo.com.au
 Peter Miller;E\[hy]Mail:;pmiller@opensource.org.au
 .TE
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new-filter.so
+++ b/doc/etc/new-filter.so
@@ -160,4 +160,3 @@ l l l.
 Scott Finneran;E\[hy]Mail:;scottfinneran@yahoo.com.au
 Peter Miller;E\[hy]Mail:;pmiller@opensource.org.au
 .TE
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.27.so
+++ b/doc/etc/new.1.27.so
@@ -25,4 +25,3 @@ MC68EZ328 Dragonball bootstrap b\[hy]record format
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.27 (2006\[hy]Dec\[hy]21)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.28.so
+++ b/doc/etc/new.1.28.so
@@ -24,4 +24,3 @@ A serious bug has been fixed in the generated Makefile.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.28 (2007-Mar-08)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.29.so
+++ b/doc/etc/new.1.29.so
@@ -40,4 +40,3 @@ it now understands the '0' tag.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.29 (2007\[hy]Mar\[hy]13)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.30.so
+++ b/doc/etc/new.1.30.so
@@ -31,4 +31,3 @@ for reading and writing.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.30 (2007\[hy]Mar\[hy]21)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.31.so
+++ b/doc/etc/new.1.31.so
@@ -32,4 +32,3 @@ like them, but the MSP430 handles them without a hiccup.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.31 (2007\[hy]Apr\[hy]03)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.32.so
+++ b/doc/etc/new.1.32.so
@@ -49,4 +49,3 @@ multiples of a number of bytes.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.32 (2007\[hy]Apr\[hy]24)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.33.so
+++ b/doc/etc/new.1.33.so
@@ -29,4 +29,3 @@ Several build problems have been fixed.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.33 (2007-May-18)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.34.so
+++ b/doc/etc/new.1.34.so
@@ -23,4 +23,3 @@ A major build problem with the generated makefile has been fixed.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.34 (2007-Jun-22)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.35.so
+++ b/doc/etc/new.1.35.so
@@ -43,4 +43,3 @@ The license has been changed to GNU GPL version 3.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.35 (2007\[hy]Jun\[hy]23)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.36.so
+++ b/doc/etc/new.1.36.so
@@ -37,4 +37,3 @@ so \f[I]sharutils\fP is no longer a build dependency.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.36 (2007\[hy]Aug\[hy]07)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.37.so
+++ b/doc/etc/new.1.37.so
@@ -47,4 +47,3 @@ The ability to negate expressions is now mentioned in the
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.37 (2007\[hy]Oct\[hy]29)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.38.so
+++ b/doc/etc/new.1.38.so
@@ -32,4 +32,3 @@ and override the default precedences.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.38 (2008-Jan-14)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.39.so
+++ b/doc/etc/new.1.39.so
@@ -50,4 +50,3 @@ default CCITT (all bits on) initial state.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.39 (2008\[hy]Feb\[hy]04)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.40.so
+++ b/doc/etc/new.1.40.so
@@ -52,4 +52,3 @@ updated.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.40 (2008\[hy]Mar\[hy]13)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.41.so
+++ b/doc/etc/new.1.41.so
@@ -32,4 +32,3 @@ load files have been added to the \f[I]srec_examples\fP(1) man page.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.41 (2008-May-12)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.42.so
+++ b/doc/etc/new.1.42.so
@@ -50,4 +50,3 @@ even when there is no execution start address passed in.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.42 (2008\[hy]Jun\[hy]01)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.43.so
+++ b/doc/etc/new.1.43.so
@@ -57,4 +57,3 @@ used to select the desired line termination of output text files.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.43 (2008\[hy]Jul\[hy]06)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.44.so
+++ b/doc/etc/new.1.44.so
@@ -32,4 +32,3 @@ The \f[I]srec_cat\fP(1) command is now able to write FORTH output.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.44 (2008-Aug-29)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.45.so
+++ b/doc/etc/new.1.45.so
@@ -38,4 +38,3 @@ and \-maximum\[hy]address, to avoid a command line grammar syntax problem.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.45 (2008\[hy]Sep\[hy]30)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.46.so
+++ b/doc/etc/new.1.46.so
@@ -25,4 +25,3 @@ reading and writing.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.46 (2009-Jan-13)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.47.so
+++ b/doc/etc/new.1.47.so
@@ -31,4 +31,3 @@ There are new Adler Checksum filters, both 32\[hy]bits and
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.47 (2009\[hy]Feb\[hy]19)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.48.so
+++ b/doc/etc/new.1.48.so
@@ -33,4 +33,3 @@ A typo in the srec_input(1) man page has been fixed.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.48 (2009-Apr-19)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.49.so
+++ b/doc/etc/new.1.49.so
@@ -44,4 +44,3 @@ See \f[I]srec_input\fP(1) for more information.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.49 (2009\[hy]May\[hy]17)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.50.so
+++ b/doc/etc/new.1.50.so
@@ -33,4 +33,3 @@ placed into separate segments.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.50 (2009\[hy]Jul\[hy]09)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.51.so
+++ b/doc/etc/new.1.51.so
@@ -28,4 +28,3 @@ See \f[I]srec_input\fP(1) for more information.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.51 (2009\[hy]Sep\[hy]13)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.52.so
+++ b/doc/etc/new.1.52.so
@@ -39,4 +39,3 @@ The code will build without libgcrypt.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.52 (2009-Sep-17)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.53.so
+++ b/doc/etc/new.1.53.so
@@ -43,4 +43,3 @@ A number of build problems have been fixed.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.53 (2009-Nov-10)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.54.so
+++ b/doc/etc/new.1.54.so
@@ -31,4 +31,3 @@ commands, shared libraries and development files.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.54 (2010\[hy]Jan-29)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.55.so
+++ b/doc/etc/new.1.55.so
@@ -56,4 +56,3 @@ with the line length option.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.55 (2010-Feb-10)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.56.so
+++ b/doc/etc/new.1.56.so
@@ -59,4 +59,3 @@ reporting this problem.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.56 (2010\[hy]Sep\[hy]15)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.57.so
+++ b/doc/etc/new.1.57.so
@@ -76,4 +76,3 @@ this problem.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.57 (2011-Jun-09)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.58.so
+++ b/doc/etc/new.1.58.so
@@ -26,4 +26,3 @@ See \f[I]srec_input\fP(1) for more information.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.58 (2011\[hy]Dec\[hy]18)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.59.so
+++ b/doc/etc/new.1.59.so
@@ -27,4 +27,3 @@ for a table of names and values.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
 .SS Version 1.59 (2012\[hy]Feb\[hy]10)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.60.so
+++ b/doc/etc/new.1.60.so
@@ -39,4 +39,3 @@ Coefficient File Format (.coe) output class.
 .\" Add new entries above this line.
 .ne 2i
 .SS Version 1.60 (2012\[hy]May\[hy]19)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.61.so
+++ b/doc/etc/new.1.61.so
@@ -48,4 +48,3 @@ escapes (e.g. %25) to the string on he command line. For example:
 .\" Add new entries above this line.
 .ne 2i
 .SS Version 1.61 (2013\[hy]Jan\[hy]04)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.62.so
+++ b/doc/etc/new.1.62.so
@@ -28,4 +28,3 @@
 .\" Add new entries above this line.
 .ne 2i
 .SS Version 1.62 (2013\[hy]Jun\[hy]05)
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.63.so
+++ b/doc/etc/new.1.63.so
@@ -104,4 +104,3 @@ Added more links to the windows files on SourceForge, maybe it
 will boost download numbers.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.64.so
+++ b/doc/etc/new.1.64.so
@@ -119,4 +119,3 @@ Added a regression test for calculated address for CRC
 (Sourceforge bug 19).
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
-.\" vim: set ts=8 sw=4 et :

--- a/doc/etc/new.1.65.so
+++ b/doc/etc/new.1.65.so
@@ -282,4 +282,3 @@ Marksu Heidelberg <markus.heidelberg@web.de> contributed a patch to fix a bug th
 Completely new build and config system to replace Aegis, Cook and autoconf with cmake & git. Integration with cpack to generate linux and windows packages. Integration with ctest to sustain the regression test suite.
 .\" ------------------------------------------------------------------------
 .\" Add new entries above this line.
-.\" vim: set ts=8 sw=4 et :

--- a/doc/html/download.html
+++ b/doc/html/download.html
@@ -182,4 +182,3 @@ width="210" height="62" border="0" alt="SourceForge.net Logo"
 align="right"></a>
 This page is hosted by <a href="http://sourceforge.net/">SourceForge</a>.
 </body></html>
-.\" vim: set ts=8 sw=4 et :

--- a/doc/html/index.html
+++ b/doc/html/index.html
@@ -570,4 +570,3 @@ width="210" height="62" border="0" alt="SourceForge.net Logo"
 align="right"></a>
 This page is hosted by <a href="http://sourceforge.net/" >SourceForge</a>.
 </body></html>
-.\" vim: set ts=8 sw=4 et :

--- a/doc/man1/o_multiple.so
+++ b/doc/man1/o_multiple.so
@@ -50,4 +50,3 @@ error
 A fatal error is issued when contradictory settings are observed, the
 fatal error message includes the problematic address and byte values.
 .RE
-.\" vim: set ts=8 sw=4 et :

--- a/doc/man1/srec_cat.1
+++ b/doc/man1/srec_cat.1
@@ -624,4 +624,3 @@ All other options will produce a diagnostic error.
 .so man1/z_options.so
 .so man1/z_exit.so
 .so man1/z_copyright.so
-.\" vim: set ts=8 sw=4 et :

--- a/doc/man1/srec_cmp.1
+++ b/doc/man1/srec_cmp.1
@@ -91,4 +91,3 @@ single contiguous piece of memory.  In the above example, the portions
 of the image which have the same address range as the signature are
 compared with the signature.
 .so man1/z_copyright.so
-.\" vim: set ts=8 sw=4 et :

--- a/doc/man1/srec_examples.1
+++ b/doc/man1/srec_examples.1
@@ -1381,4 +1381,3 @@ The above example performs a bit\[hy]wise NOT of the data bytes.
 The addresses of records are unchanged.
 Security by obscurity?
 .so man1/z_copyright.so
-.\" vim: set ts=8 sw=4 et :

--- a/doc/man1/srec_info.1
+++ b/doc/man1/srec_info.1
@@ -78,4 +78,3 @@ All other options will produce a diagnostic error.
 .so man1/z_options.so
 .so man1/z_exit.so
 .so man1/z_copyright.so
-.\" vim: set ts=8 sw=4 et :

--- a/doc/man1/srec_input.1
+++ b/doc/man1/srec_input.1
@@ -1209,4 +1209,3 @@ they can't be within the text of the preceding or following option,
 and you will need to quote them to get them past the shell,
 as \f[CW]'('\fP and \f[CW]')'\fP.
 .so man1/z_copyright.so
-.\" vim: set ts=8 sw=4 et :

--- a/doc/man1/z_copyright.so
+++ b/doc/man1/z_copyright.so
@@ -45,4 +45,3 @@ l r l.
 Scott Finneran;E\[hy]Mail:;scottfinneran@yahoo.com.au
 Peter Miller;E\[hy]Mail:;pmiller@opensource.org.au
 .TE
-.\" vim: set ts=8 sw=4 et :

--- a/doc/man3/srecord.3
+++ b/doc/man3/srecord.3
@@ -32,4 +32,3 @@ from the source files, and is available on the Internet at
 .br
 http://srecord.sourceforge.net/srecord/index.html
 .so man1/z_copyright.so
-.\" vim: set ts=8 sw=4 et :

--- a/doc/man5/srec_binary.5
+++ b/doc/man5/srec_binary.5
@@ -91,4 +91,3 @@ has a section about binary files, and ways of automagically
 offseting the data back to zero in a single command.
 .ds n) SRrecord
 .so man1/z_copyright.so
-.\" vim: set ts=8 sw=4 et :

--- a/doc/man5/srec_brecord.5
+++ b/doc/man5/srec_brecord.5
@@ -93,4 +93,3 @@ It contains the data \[lq]Hello, World\[rq] to be loaded at address 0.
 http://www.freescale.com/files/32bit/doc/ref_manual/MC68VZ328UM.pdf
 .ds n) srec_cat
 .so man1/z_copyright.so
-.\" vim: set ts=8 sw=4 et :

--- a/doc/man5/srec_coe.5
+++ b/doc/man5/srec_coe.5
@@ -49,4 +49,3 @@ http://www.xilinx.com/support/documentation/sw_manuals/xilinx11/\
 cgn_r_coe_file_syntax.htm
 .ne 1i
 .so man1/z_copyright.so
-.\" vim: set ts=8 sw=4 et :

--- a/doc/man5/srec_idt.5
+++ b/doc/man5/srec_idt.5
@@ -41,4 +41,3 @@ For a different spin on making S\[hy]Record into a more densely packed
 binary file.
 .ds n) srec_cat
 .so man1/z_copyright.so
-.\" vim: set ts=8 sw=4 et :

--- a/doc/man5/srec_logisim.5
+++ b/doc/man5/srec_logisim.5
@@ -71,4 +71,3 @@ There is no provision for an execution start adddress.
 .SH SEE ALSO
 http://ozark.hendrix.edu/~burch/logisim/docs/2.3.0/guide/mem/menu.html
 .so man1/z_copyright.so
-.\" vim: set ts=8 sw=4 et :

--- a/doc/man5/srec_mem.5
+++ b/doc/man5/srec_mem.5
@@ -152,4 +152,3 @@ Width;Linux;Windows
 This format is implicitly big\[hy]endian.
 Use a \-byte\[hy]swap filter if you need something different.
 .so man1/z_copyright.so
-.\" vim: set ts=8 sw=4 et :

--- a/doc/man5/srec_mif.5
+++ b/doc/man5/srec_mif.5
@@ -207,4 +207,3 @@ glossary/def_mif.html
 http://www.mil.ufl.edu/4712/docs/mif_help.pdf
 .fi
 .so man1/z_copyright.so
-.\" vim: set ts=8 sw=4 et :

--- a/doc/man5/srec_mips_flash.5
+++ b/doc/man5/srec_mips_flash.5
@@ -81,4 +81,3 @@ It contains the data \[lq]Hello, World\[rq] to be loaded at bytes address 0x0000
 .ds n) srec_cat
 .so man1/z_copyright.so
 .so man1/z_copyright.so
-.\" vim: set ts=8 sw=4 et :

--- a/doc/man5/srec_ppb.5
+++ b/doc/man5/srec_ppb.5
@@ -49,4 +49,3 @@ https://web.archive.org/web/20110417235840/http://www.stag.co.uk/
 .\" ------------------------------------------------------------------------
 .ds n) srec_cat
 .so man1/z_copyright.so
-.\" vim: set ts=8 sw=4 et :

--- a/doc/man5/srec_ppx.5
+++ b/doc/man5/srec_ppx.5
@@ -58,4 +58,3 @@ https://web.archive.org/web/20110417235840/http://www.stag.co.uk/
 .\" ------------------------------------------------------------------------
 .ds n) srec_cat
 .so man1/z_copyright.so
-.\" vim: set ts=8 sw=4 et :

--- a/doc/man5/srec_ti_txt.5
+++ b/doc/man5/srec_ti_txt.5
@@ -63,4 +63,3 @@ http://www.ti.com/lit/pdf/slau101, section A.2.
 \f[B]Note:\fP the portion which says addresses must be even, and the
 number of data bytes in a section must be even, is wrong.
 .so man1/z_copyright.so
-.\" vim: set ts=8 sw=4 et :

--- a/doc/man5/srec_trs80.5
+++ b/doc/man5/srec_trs80.5
@@ -122,4 +122,3 @@ Tandy Corporation,
 .\" ------------------------------------------------------------------------
 .ds n) srec_cat
 .so man1/z_copyright.so
-.\" vim: set ts=8 sw=4 et :

--- a/doc/script/groff.sh
+++ b/doc/script/groff.sh
@@ -28,5 +28,3 @@ then
 fi
 
 exit 0
-
-# vim: set ts=8 sw=4 et :

--- a/doc/script/man-html-index.sh
+++ b/doc/script/man-html-index.sh
@@ -57,5 +57,3 @@ echo "</ul>"
 echo "</body>"
 echo "</html>"
 exit 0
-
-# vim: set ts=8 sw=4 et :

--- a/doc/script/new.sh
+++ b/doc/script/new.sh
@@ -29,4 +29,3 @@ do
         echo ".so $f"
 done
 exit 0
-# vim: set ts=8 sw=4 et :

--- a/etc/howto_qemu_hardy64.txt
+++ b/etc/howto_qemu_hardy64.txt
@@ -19,4 +19,3 @@ qemu-img create hardy64.img 5G
 qemu-system-x86_64 -net nic -net user -m 1G \
     -cdrom /home/vault/iso/ubuntu-8.04.4-desktop-amd64.iso \
     -hda hardy-amd64.img
-# vim: set ts=8 sw=4 et :

--- a/etc/template/c
+++ b/etc/template/c
@@ -23,5 +23,3 @@ void
 ${id ${trim_ext $fn}}()
 {
 }
-
-/* vim: set ts=8 sw=4 et : */

--- a/etc/template/cc
+++ b/etc/template/cc
@@ -48,5 +48,3 @@ ${id ${trim_dir ${trim_ext $fn}}}::operator=(const ${id ${trim_dir ${trim_ext
     }
     return *this;
 }
-
-// vim: set ts=8 sw=4 et :

--- a/etc/template/etc-new-so
+++ b/etc/template/etc-new-so
@@ -30,4 +30,3 @@
 .\" Add new entries above this line.
 .ne 2i
 .SS Version ${project version} (${date %Y\\[hy]%b\\[hy]%d})
-.\" vim: set ts=8 sw=4 et :

--- a/etc/template/generic
+++ b/etc/template/generic
@@ -15,5 +15,3 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-
-# vim: set ts=8 sw=4 et :

--- a/etc/template/h
+++ b/etc/template/h
@@ -51,5 +51,4 @@ public:
         ${trim_ext $fn}}} &);
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // ${id ${upcase $fn}}

--- a/etc/template/lib_cc
+++ b/etc/template/lib_cc
@@ -49,6 +49,3 @@ srecord::${id ${trim_dir ${trim_ext $fn}}}::operator=(const ${id ${trim_dir
     }
     return *this;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/etc/template/lib_h
+++ b/etc/template/lib_h
@@ -55,5 +55,4 @@ public:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // ${id ${upcase $fn}}

--- a/etc/template/man
+++ b/etc/template/man
@@ -59,4 +59,3 @@ All other options will produce a diagnostic error.
 .so z_options.so
 .so z_exit.so
 .so z_copyright.so
-.\" vim: set ts=8 sw=4 et :

--- a/etc/template/sh
+++ b/etc/template/sh
@@ -18,5 +18,3 @@
 #
 
 exit 0
-
-# vim: set ts=8 sw=4 et :

--- a/etc/template/test
+++ b/etc/template/test
@@ -41,5 +41,3 @@ if test $$? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/srec_cat/arglex3.cc
+++ b/srec_cat/arglex3.cc
@@ -56,6 +56,3 @@ srec_cat_arglex3::srec_cat_arglex3(int argc, char **argv) :
 srec_cat_arglex3::~srec_cat_arglex3()
 {
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srec_cat/arglex3.h
+++ b/srec_cat/arglex3.h
@@ -71,4 +71,3 @@ private:
 };
 
 #endif // PROG_SREC_CAT_ARGLEX3_H
-// vim: set ts=8 sw=4 et :

--- a/srec_cat/main.cc
+++ b/srec_cat/main.cc
@@ -281,6 +281,3 @@ main(int argc, char **argv)
     //
     return EXIT_SUCCESS;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srec_cmp/main.cc
+++ b/srec_cmp/main.cc
@@ -152,6 +152,3 @@ main(int argc, char **argv)
     //
     return 0;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srec_info/main.cc
+++ b/srec_info/main.cc
@@ -187,6 +187,3 @@ main(int argc, char **argv)
     //
     return EXIT_SUCCESS;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/CMakeLists.txt
+++ b/srecord/CMakeLists.txt
@@ -36,7 +36,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 # Install the Doxygen output for the website
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html
         DESTINATION ${CMAKE_INSTALL_DOCDIR}/htdocs/srecord
- 	COMPONENT website)
+        COMPONENT website)
 
 # Generate config.h to suit local environment
 configure_file(config.h.in config.h @ONLY)
@@ -46,4 +46,4 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 # Generate doxygen content
 doxygen_add_docs(doxygen
                  ${LIB_SRECORD_HDR}
-		 ALL)
+                 ALL)

--- a/srecord/adler16.cc
+++ b/srecord/adler16.cc
@@ -78,6 +78,3 @@ srecord::adler16::nextbuf(const void *data, size_t nbytes)
         --nbytes;
     }
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/adler16.h
+++ b/srecord/adler16.h
@@ -83,5 +83,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_ADLER16_H

--- a/srecord/adler32.cc
+++ b/srecord/adler32.cc
@@ -78,6 +78,3 @@ srecord::adler32::nextbuf(const void *data, size_t nbytes)
         --nbytes;
     }
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/adler32.h
+++ b/srecord/adler32.h
@@ -86,5 +86,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_ADLER32_H

--- a/srecord/arglex.cc
+++ b/srecord/arglex.cc
@@ -807,5 +807,3 @@ srecord::arglex::fatal_error(const char *fmt, ...)
     // NOTREACHED
     va_end(ap);
 }
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/arglex.h
+++ b/srecord/arglex.h
@@ -383,4 +383,3 @@ protected:
 };
 
 #endif // LIB_ARGLEX_H
-// vim: set ts=8 sw=4 et :

--- a/srecord/arglex/abbreviate.cc
+++ b/srecord/arglex/abbreviate.cc
@@ -51,6 +51,3 @@ srecord::arglex::abbreviate(const char *s)
         }
     }
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/arglex/test_ambiguous.cc
+++ b/srecord/arglex/test_ambiguous.cc
@@ -80,6 +80,3 @@ srecord::arglex::test_ambiguous(void)
         exit(1);
     }
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/arglex/tool.cc
+++ b/srecord/arglex/tool.cc
@@ -434,6 +434,3 @@ srecord::arglex_tool::default_command_line_processing(void)
         break;
     }
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/arglex/tool.h
+++ b/srecord/arglex/tool.h
@@ -481,5 +481,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_ARGLEX_TOOL_H

--- a/srecord/arglex/tool/input.cc
+++ b/srecord/arglex/tool/input.cc
@@ -1151,6 +1151,3 @@ srecord::arglex_tool::get_input()
         ifp->command_line(this);
     }
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/arglex/tool/output.cc
+++ b/srecord/arglex/tool/output.cc
@@ -363,6 +363,3 @@ srecord::arglex_tool::get_output()
     //
     return ofp;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/bitrev.cc
+++ b/srecord/bitrev.cc
@@ -147,6 +147,3 @@ srecord::bitrev64(unsigned long long value)
     // hi2 must have same type as return
     return ((hi2 << 32) | lo2);
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/bitrev.h
+++ b/srecord/bitrev.h
@@ -96,5 +96,4 @@ unsigned long long bitrev64(unsigned long long value);
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_BITREV_H

--- a/srecord/crc16.cc
+++ b/srecord/crc16.cc
@@ -390,6 +390,3 @@ srecord::crc16::polynomial_by_name(const char *name)
     );
     return polynomial_ccitt;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/defcon.cc
+++ b/srecord/defcon.cc
@@ -82,6 +82,3 @@ srecord::defcon_from_text(const char *text)
         return -1;
     return tp->value;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/defcon.h
+++ b/srecord/defcon.h
@@ -36,5 +36,4 @@ int defcon_from_text(const char *text);
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_DEFCON_H

--- a/srecord/endian.h
+++ b/srecord/endian.h
@@ -71,5 +71,4 @@ unsigned short endian_decode_word(const unsigned char *data, endian_t order);
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_ENDIAN_H

--- a/srecord/endian/decode_word.cc
+++ b/srecord/endian/decode_word.cc
@@ -45,6 +45,3 @@ srecord::endian_decode_word(const unsigned char *data, endian_t order)
             decode_word_be(data)
         );
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/fletcher16.cc
+++ b/srecord/fletcher16.cc
@@ -217,5 +217,3 @@ srecord::fletcher16::get()
 
     return (((sum1 & 0xFF) << 8) | (sum2 & 0xFF));
 }
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/fletcher16.h
+++ b/srecord/fletcher16.h
@@ -154,5 +154,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_FLETCHER16_H

--- a/srecord/fletcher32.cc
+++ b/srecord/fletcher32.cc
@@ -117,6 +117,3 @@ srecord::fletcher32::get()
 {
     return ((sum2 << 16) | sum1);
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/fletcher32.h
+++ b/srecord/fletcher32.h
@@ -107,5 +107,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_FLETCHER32_H

--- a/srecord/input.h
+++ b/srecord/input.h
@@ -180,5 +180,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_INPUT_H

--- a/srecord/input/catenate.cc
+++ b/srecord/input/catenate.cc
@@ -113,6 +113,3 @@ srecord::input_catenate::disable_checksum_validation()
         in1->disable_checksum_validation();
     in2->disable_checksum_validation();
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/catenate.h
+++ b/srecord/input/catenate.h
@@ -108,5 +108,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_INPUT_CATENATE_H

--- a/srecord/input/file.cc
+++ b/srecord/input/file.cc
@@ -344,6 +344,3 @@ srecord::input_file::disable_checksum_validation(void)
 {
     ignore_checksums = true;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file.h
+++ b/srecord/input/file.h
@@ -338,5 +338,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_INPUT_FILE_H

--- a/srecord/input/file/aomf.cc
+++ b/srecord/input/file/aomf.cc
@@ -307,6 +307,3 @@ srecord::input_file_aomf::format_option_number(void)
 {
     return arglex_tool::token_aomf;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/aomf.h
+++ b/srecord/input/file/aomf.h
@@ -146,5 +146,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_INPUT_FILE_AOMF_H

--- a/srecord/input/file/ascii_hex.cc
+++ b/srecord/input/file/ascii_hex.cc
@@ -193,6 +193,3 @@ srecord::input_file_ascii_hex::format_option_number(void)
 {
     return arglex_tool::token_ascii_hex;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/ascii_hex.h
+++ b/srecord/input/file/ascii_hex.h
@@ -115,4 +115,3 @@ private:
 };
 
 #endif // SRECORD_INPUT_FILE_ASCII_HEX_H
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/atmel_generic.cc
+++ b/srecord/input/file/atmel_generic.cc
@@ -122,6 +122,3 @@ srecord::input_file_atmel_generic::format_option_number(void)
             arglex_tool::token_atmel_generic_le
         );
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/atmel_generic.h
+++ b/srecord/input/file/atmel_generic.h
@@ -120,4 +120,3 @@ private:
 };
 
 #endif // SRECORD_INPUT_FILE_ATMEL_GENERIC_H
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/binary.cc
+++ b/srecord/input/file/binary.cc
@@ -99,6 +99,3 @@ srecord::input_file_binary::format_option_number(void)
 {
     return arglex_tool::token_binary;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/binary.h
+++ b/srecord/input/file/binary.h
@@ -94,4 +94,3 @@ private:
 };
 
 #endif // SRECORD_INPUT_FILE_BINARY_H
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/brecord.cc
+++ b/srecord/input/file/brecord.cc
@@ -99,6 +99,3 @@ srecord::input_file_brecord::format_option_number(void)
 {
     return arglex_tool::token_brecord;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/brecord.h
+++ b/srecord/input/file/brecord.h
@@ -96,5 +96,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_INPUT_FILE_BRECORD_H

--- a/srecord/input/file/cosmac.cc
+++ b/srecord/input/file/cosmac.cc
@@ -154,6 +154,3 @@ srecord::input_file_cosmac::format_option_number(void)
 {
     return arglex_tool::token_cosmac;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/cosmac.h
+++ b/srecord/input/file/cosmac.h
@@ -110,4 +110,3 @@ private:
 };
 
 #endif // SRECORD_INPUT_FILE_COSMAC_H
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/dec_binary.cc
+++ b/srecord/input/file/dec_binary.cc
@@ -168,6 +168,3 @@ srecord::input_file_dec_binary::format_option_number(void)
 {
     return arglex_tool::token_dec_binary;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/dec_binary.h
+++ b/srecord/input/file/dec_binary.h
@@ -122,5 +122,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_INPUT_FILE_DEC_BINARY_H

--- a/srecord/input/file/emon52.cc
+++ b/srecord/input/file/emon52.cc
@@ -109,6 +109,3 @@ srecord::input_file_emon52::format_option_number(void)
 {
     return arglex_tool::token_emon52;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/emon52.h
+++ b/srecord/input/file/emon52.h
@@ -93,4 +93,3 @@ private:
 };
 
 #endif // SRECORD_INPUT_FILE_EMON52_H
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/fairchild.cc
+++ b/srecord/input/file/fairchild.cc
@@ -151,6 +151,3 @@ srecord::input_file_fairchild::format_option_number(void)
 {
     return arglex_tool::token_fairchild;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/fairchild.h
+++ b/srecord/input/file/fairchild.h
@@ -117,4 +117,3 @@ private:
 };
 
 #endif // SRECORD_INPUT_FILE_FAIRCHILD_H
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/fastload.cc
+++ b/srecord/input/file/fastload.cc
@@ -322,6 +322,3 @@ srecord::input_file_fastload::format_option_number(void)
 {
     return arglex_tool::token_fast_load;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/fastload.h
+++ b/srecord/input/file/fastload.h
@@ -124,4 +124,3 @@ private:
 };
 
 #endif // SRECORD_INPUT_FILE_FASTLOAD_H
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/formatted_binary.cc
+++ b/srecord/input/file/formatted_binary.cc
@@ -184,6 +184,3 @@ srecord::input_file_formatted_binary::format_option_number(void)
 {
     return arglex_tool::token_formatted_binary;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/formatted_binary.h
+++ b/srecord/input/file/formatted_binary.h
@@ -118,4 +118,3 @@ private:
 };
 
 #endif // SRECORD_INPUT_FILE_FORMATTED_BINARY_H
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/four_packed_code.cc
+++ b/srecord/input/file/four_packed_code.cc
@@ -276,6 +276,3 @@ srecord::input_file_four_packed_code::format_option_number(void)
 {
     return arglex_tool::token_four_packed_code;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/four_packed_code.h
+++ b/srecord/input/file/four_packed_code.h
@@ -145,4 +145,3 @@ private:
 };
 
 #endif // SRECORD_INPUT_FILE_FOUR_PACKED_CODE_H
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/guess.cc
+++ b/srecord/input/file/guess.cc
@@ -192,6 +192,3 @@ srecord::input_file::guess(const std::string &fn, arglex &cmdline)
     );
     return srecord::input_file_binary::create(fn);
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/hexdump.cc
+++ b/srecord/input/file/hexdump.cc
@@ -212,6 +212,3 @@ srecord::input_file_hexdump::format_option_number(void)
 {
     return arglex_tool::token_hexdump;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/hexdump.h
+++ b/srecord/input/file/hexdump.h
@@ -126,5 +126,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_INPUT_FILE_HEXDUMP_H

--- a/srecord/input/file/hp64k.cc
+++ b/srecord/input/file/hp64k.cc
@@ -145,8 +145,8 @@ srecord::input_file_hp64k::read_datarec(record &result)
     return true;
 }
 
-#define HP64_MAGIC 0x8204U	//file signature, before header
-#define HP64_HDRLEN 16	//8 words
+#define HP64_MAGIC 0x8204U  //file signature, before header
+#define HP64_HDRLEN 16      //8 words
 bool
 srecord::input_file_hp64k::read_hdr(record &result)
 {
@@ -162,7 +162,7 @@ srecord::input_file_hp64k::read_hdr(record &result)
     }
 
     unsigned cnt;
-    unsigned len = HP64_HDRLEN;	//initial value assume full buffer.
+    unsigned len = HP64_HDRLEN; //initial value assume full buffer.
     uint8_t hdr[HP64_HDRLEN + 1];
 
     for (cnt=0; cnt < HP64_HDRLEN; cnt++)
@@ -178,8 +178,8 @@ srecord::input_file_hp64k::read_hdr(record &result)
             len = cnt;
         }
     }
-    len++;	//include 0-term
-    hdr[HP64_HDRLEN] = 0;	//ensure 0-term
+    len++;                  //include 0-term
+    hdr[HP64_HDRLEN] = 0;   //ensure 0-term
     result = record(record::type_header, 0, hdr, len);
     return true;
 }

--- a/srecord/input/file/hp64k.cc
+++ b/srecord/input/file/hp64k.cc
@@ -279,6 +279,3 @@ srecord::input_file_hp64k::format_option_number(void)
 {
     return arglex_tool::token_hp64k;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/hp64k.h
+++ b/srecord/input/file/hp64k.h
@@ -114,4 +114,3 @@ private:
 };
 
 #endif // LIB_INPUT_FILE_HP64K
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/idt.cc
+++ b/srecord/input/file/idt.cc
@@ -263,6 +263,3 @@ srecord::input_file_idt::format_option_number(void)
 {
     return arglex_tool::token_idt;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/idt.h
+++ b/srecord/input/file/idt.h
@@ -111,5 +111,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_INPUT_FILE_IDT_H

--- a/srecord/input/file/intel.cc
+++ b/srecord/input/file/intel.cc
@@ -428,6 +428,3 @@ srecord::input_file_intel::format_option_number(void)
 {
     return arglex_tool::token_intel;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/intel.h
+++ b/srecord/input/file/intel.h
@@ -147,4 +147,3 @@ private:
 };
 
 #endif // SRECORD_INPUT_FILE_INTEL_H
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/intel16.cc
+++ b/srecord/input/file/intel16.cc
@@ -364,6 +364,3 @@ srecord::input_file_intel16::format_option_number(void)
 {
     return arglex_tool::token_intel16;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/intel16.h
+++ b/srecord/input/file/intel16.h
@@ -141,4 +141,3 @@ private:
 };
 
 #endif // SRECORD_INPUT_FILE_INTEL16_H
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/logisim.cc
+++ b/srecord/input/file/logisim.cc
@@ -304,6 +304,3 @@ srecord::input_file_logisim::datum_t::representation(void)
     );
     return buffer;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/logisim.h
+++ b/srecord/input/file/logisim.h
@@ -150,5 +150,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_INPUT_FILE_LOGISIM_H

--- a/srecord/input/file/mif.cc
+++ b/srecord/input/file/mif.cc
@@ -471,6 +471,3 @@ srecord::input_file_mif::format_option_number(void)
 {
     return arglex_tool::token_memory_initialization_file;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/mif.h
+++ b/srecord/input/file/mif.h
@@ -191,5 +191,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_INPUT_FILE_MIF_H

--- a/srecord/input/file/mips_flash.cc
+++ b/srecord/input/file/mips_flash.cc
@@ -232,6 +232,3 @@ srecord::input_file_mips_flash::format_option_number(void)
             arglex_tool::token_mips_flash_le
         );
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/mips_flash.h
+++ b/srecord/input/file/mips_flash.h
@@ -162,5 +162,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_INPUT_FILE_MIPS_FLASH_H

--- a/srecord/input/file/mos_tech.cc
+++ b/srecord/input/file/mos_tech.cc
@@ -164,6 +164,3 @@ srecord::input_file_mos_tech::format_option_number(void)
 {
     return arglex_tool::token_mos_tech;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/mos_tech.h
+++ b/srecord/input/file/mos_tech.h
@@ -110,4 +110,3 @@ private:
 };
 
 #endif // SRECORD_INPUT_FILE_MOS_TECH_H
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/motorola.cc
+++ b/srecord/input/file/motorola.cc
@@ -347,6 +347,3 @@ srecord::input_file_motorola::format_option_number(void)
 {
     return arglex_tool::token_motorola;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/motorola.h
+++ b/srecord/input/file/motorola.h
@@ -138,4 +138,3 @@ private:
 };
 
 #endif // LIB_INPUT_FILE_MOTOROLA_H
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/msbin.cc
+++ b/srecord/input/file/msbin.cc
@@ -323,6 +323,3 @@ srecord::input_file_msbin::format_option_number(void)
 {
     return arglex_tool::token_msbin;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/msbin.h
+++ b/srecord/input/file/msbin.h
@@ -202,4 +202,3 @@ private:
 };
 
 #endif // SRECORD_INPUT_FILE_MSBIN_H
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/needham.cc
+++ b/srecord/input/file/needham.cc
@@ -123,6 +123,3 @@ srecord::input_file_needham::format_option_number(void)
 {
     return arglex_tool::token_needham_hex;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/needham.h
+++ b/srecord/input/file/needham.h
@@ -90,4 +90,3 @@ private:
 };
 
 #endif // SRECORD_INPUT_FILE_NEEDHAM_H
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/os65v.cc
+++ b/srecord/input/file/os65v.cc
@@ -181,6 +181,3 @@ srecord::input_file_os65v::format_option_number(void)
 {
     return arglex_tool::token_ohio_scientific;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/os65v.h
+++ b/srecord/input/file/os65v.h
@@ -117,4 +117,3 @@ private:
 };
 
 #endif // SRECORD_INPUT_FILE_OS65V_H
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/ppb.cc
+++ b/srecord/input/file/ppb.cc
@@ -188,6 +188,3 @@ srecord::input_file_ppb::format_option_number(void)
 {
     return arglex_tool::token_ppb;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/ppb.h
+++ b/srecord/input/file/ppb.h
@@ -138,5 +138,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_INPUT_FILE_PPB_H

--- a/srecord/input/file/ppx.cc
+++ b/srecord/input/file/ppx.cc
@@ -324,6 +324,3 @@ srecord::input_file_ppx::format_option_number(void)
 {
     return arglex_tool::token_ppx;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/ppx.h
+++ b/srecord/input/file/ppx.h
@@ -161,5 +161,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_INPUT_FILE_PPX_H

--- a/srecord/input/file/signetics.cc
+++ b/srecord/input/file/signetics.cc
@@ -154,6 +154,3 @@ srecord::input_file_signetics::format_option_number(void)
 {
     return arglex_tool::token_signetics;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/signetics.h
+++ b/srecord/input/file/signetics.h
@@ -111,4 +111,3 @@ private:
 };
 
 #endif // SRECORD_INPUT_FILE_SIGNETICS_H
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/spasm.cc
+++ b/srecord/input/file/spasm.cc
@@ -131,6 +131,3 @@ srecord::input_file_spasm::format_option_number(void)
             arglex_tool::token_spasm_le
         );
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/spasm.h
+++ b/srecord/input/file/spasm.h
@@ -120,4 +120,3 @@ private:
 };
 
 #endif // SRECORD_INPUT_FILE_SPASM_H
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/spectrum.cc
+++ b/srecord/input/file/spectrum.cc
@@ -191,6 +191,3 @@ srecord::input_file_spectrum::format_option_number(void)
 {
     return arglex_tool::token_spectrum;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/spectrum.h
+++ b/srecord/input/file/spectrum.h
@@ -115,4 +115,3 @@ private:
 };
 
 #endif // SRECORD_INPUT_FILE_SPECTRUM_H
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/stewie.cc
+++ b/srecord/input/file/stewie.cc
@@ -279,6 +279,3 @@ srecord::input_file_stewie::format_option_number(void)
 {
     return arglex_tool::token_stewie;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/stewie.h
+++ b/srecord/input/file/stewie.h
@@ -128,4 +128,3 @@ private:
 };
 
 #endif // LIB_INPUT_FILE_STEWIE_H
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/tektronix.cc
+++ b/srecord/input/file/tektronix.cc
@@ -221,6 +221,3 @@ srecord::input_file_tektronix::format_option_number(void)
 {
     return arglex_tool::token_tektronix;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/tektronix.h
+++ b/srecord/input/file/tektronix.h
@@ -129,4 +129,3 @@ private:
 };
 
 #endif // SRECORD_INPUT_FILE_TEKTRONIX_H
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/tektronix_extended.cc
+++ b/srecord/input/file/tektronix_extended.cc
@@ -254,6 +254,3 @@ srecord::input_file_tektronix_extended::format_option_number(void)
 {
     return arglex_tool::token_tektronix_extended;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/tektronix_extended.h
+++ b/srecord/input/file/tektronix_extended.h
@@ -135,4 +135,3 @@ private:
 };
 
 #endif // SRECORD_INPUT_FILE_TEKTRONIX_EXTENDED_H
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/ti_tagged.cc
+++ b/srecord/input/file/ti_tagged.cc
@@ -191,6 +191,3 @@ srecord::input_file_ti_tagged::format_option_number(void)
 {
     return arglex_tool::token_ti_tagged;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/ti_tagged.h
+++ b/srecord/input/file/ti_tagged.h
@@ -113,4 +113,3 @@ private:
 };
 
 #endif // SRECORD_INPUT_FILE_TI_TAGGED_H
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/ti_tagged_16.cc
+++ b/srecord/input/file/ti_tagged_16.cc
@@ -191,6 +191,3 @@ srecord::input_file_ti_tagged_16::format_option_number(void)
 {
     return arglex_tool::token_ti_tagged_16;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/ti_tagged_16.h
+++ b/srecord/input/file/ti_tagged_16.h
@@ -112,4 +112,3 @@ private:
 };
 
 #endif // SRECORD_INPUT_FILE_TI_TAGGED_16_H
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/ti_txt.cc
+++ b/srecord/input/file/ti_txt.cc
@@ -206,6 +206,3 @@ srecord::input_file_ti_txt::format_option_number(void)
 {
     return arglex_tool::token_ti_txt;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/ti_txt.h
+++ b/srecord/input/file/ti_txt.h
@@ -140,4 +140,3 @@ private:
 };
 
 #endif // SRECORD_INPUT_FILE_ti_txt_H
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/trs80.cc
+++ b/srecord/input/file/trs80.cc
@@ -213,6 +213,3 @@ srecord::input_file_trs80::format_option_number(void)
 {
     return arglex_tool::token_trs80;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/trs80.h
+++ b/srecord/input/file/trs80.h
@@ -112,5 +112,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_INPUT_FILE_TRS80_H

--- a/srecord/input/file/vmem.cc
+++ b/srecord/input/file/vmem.cc
@@ -167,6 +167,3 @@ srecord::input_file_vmem::format_option_number(void)
 {
     return arglex_tool::token_vmem;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/vmem.h
+++ b/srecord/input/file/vmem.h
@@ -97,4 +97,3 @@ private:
 };
 
 #endif // SRECORD_INPUT_FILE_VMEM_H
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/wilson.cc
+++ b/srecord/input/file/wilson.cc
@@ -233,6 +233,3 @@ srecord::input_file_wilson::format_option_number(void)
 {
     return arglex_tool::token_wilson;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/file/wilson.h
+++ b/srecord/input/file/wilson.h
@@ -122,4 +122,3 @@ private:
 };
 
 #endif // SRECORD_INPUT_FILE_WILSON_H
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/filter.h
+++ b/srecord/input/filter.h
@@ -91,5 +91,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_INPUT_FILTER_H

--- a/srecord/input/filter/bitrev.cc
+++ b/srecord/input/filter/bitrev.cc
@@ -53,6 +53,3 @@ srecord::input_filter_bitrev::read(srecord::record &record)
     }
     return true;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/filter/bitrev.h
+++ b/srecord/input/filter/bitrev.h
@@ -78,5 +78,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_INPUT_FILTER_BITREV_H

--- a/srecord/input/filter/checksum.cc
+++ b/srecord/input/filter/checksum.cc
@@ -102,6 +102,3 @@ srecord::input_filter_checksum::read(record &record)
     }
     return true;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/filter/checksum.h
+++ b/srecord/input/filter/checksum.h
@@ -137,4 +137,3 @@ private:
 };
 
 #endif // SRECORD_INPUT_FILTER_CHECKSUM_H
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/filter/interval.cc
+++ b/srecord/input/filter/interval.cc
@@ -69,5 +69,3 @@ srecord::input_filter_interval::read(record &record)
     }
     return true;
 }
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/filter/interval.h
+++ b/srecord/input/filter/interval.h
@@ -128,5 +128,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_INPUT_FILTER_INTERVAL_H

--- a/srecord/input/filter/interval/length.h
+++ b/srecord/input/filter/interval/length.h
@@ -110,5 +110,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_INPUT_FILTER_INTERVAL_LENGTH_H

--- a/srecord/input/filter/interval/maximum.h
+++ b/srecord/input/filter/interval/maximum.h
@@ -101,5 +101,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_INPUT_FILTER_INTERVAL_MAXIMUM_H

--- a/srecord/input/filter/interval/minimum.h
+++ b/srecord/input/filter/interval/minimum.h
@@ -100,5 +100,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_INPUT_FILTER_INTERVAL_MINIMUM_H

--- a/srecord/input/filter/message.cc
+++ b/srecord/input/filter/message.cc
@@ -154,6 +154,3 @@ srecord::input_filter_message::read(record &result)
     //
     return false;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/filter/message.h
+++ b/srecord/input/filter/message.h
@@ -139,5 +139,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_INPUT_FILTER_MESSAGE_H

--- a/srecord/input/filter/message/adler16.h
+++ b/srecord/input/filter/message/adler16.h
@@ -108,5 +108,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_INPUT_FILTER_MESSAGE_ADLER16_H

--- a/srecord/input/filter/message/adler32.h
+++ b/srecord/input/filter/message/adler32.h
@@ -109,5 +109,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_INPUT_FILTER_MESSAGE_ADLER32_H

--- a/srecord/input/filter/message/fletcher16.cc
+++ b/srecord/input/filter/message/fletcher16.cc
@@ -99,6 +99,3 @@ srecord::input_filter_message_fletcher16::get_algorithm_name()
 {
     return "Fletcher-16";
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/filter/message/fletcher16.h
+++ b/srecord/input/filter/message/fletcher16.h
@@ -117,5 +117,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_INPUT_FILTER_MESSAGE_FLETCHER16_H

--- a/srecord/input/filter/message/fletcher32.cc
+++ b/srecord/input/filter/message/fletcher32.cc
@@ -81,6 +81,3 @@ srecord::input_filter_message_fletcher32::get_algorithm_name()
 {
     return "Fletcher-32";
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/filter/message/fletcher32.h
+++ b/srecord/input/filter/message/fletcher32.h
@@ -108,5 +108,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_INPUT_FILTER_MESSAGE_FLETCHER32_H

--- a/srecord/input/filter/message/gcrypt.cc
+++ b/srecord/input/filter/message/gcrypt.cc
@@ -382,6 +382,3 @@ srecord::input_filter_message_gcrypt::get_algorithm_name()
     return "libgcrypt not available";
 #endif
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/filter/message/gcrypt.h
+++ b/srecord/input/filter/message/gcrypt.h
@@ -336,5 +336,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_INPUT_FILTER_MESSAGE_GCRYPT_H

--- a/srecord/input/filter/message/stm32.cc
+++ b/srecord/input/filter/message/stm32.cc
@@ -101,6 +101,3 @@ srecord::input_filter_message_stm32::get_minimum_alignment(void)
 {
     return 4;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/filter/message/stm32.h
+++ b/srecord/input/filter/message/stm32.h
@@ -122,5 +122,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_INPUT_FILTER_MESSAGE_STM32_H

--- a/srecord/input/generator.cc
+++ b/srecord/input/generator.cc
@@ -308,6 +308,3 @@ srecord::input_generator::disable_checksum_validation()
     // Do nothing.
     // None of the generators have checksums.
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/generator.h
+++ b/srecord/input/generator.h
@@ -100,5 +100,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_INPUT_GENERATOR_H

--- a/srecord/input/generator/constant.cc
+++ b/srecord/input/generator/constant.cc
@@ -66,6 +66,3 @@ srecord::input_generator_constant::get_file_format_name()
 {
     return "constant";
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/generator/constant.h
+++ b/srecord/input/generator/constant.h
@@ -86,5 +86,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_INPUT_GENERATOR_CONSTANT_H

--- a/srecord/input/generator/random.cc
+++ b/srecord/input/generator/random.cc
@@ -61,5 +61,3 @@ srecord::input_generator_random::get_file_format_name()
 {
     return "random";
 }
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/input/generator/random.h
+++ b/srecord/input/generator/random.h
@@ -80,5 +80,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_INPUT_GENERATOR_RANDOM_H

--- a/srecord/input/generator/repeat.h
+++ b/srecord/input/generator/repeat.h
@@ -115,5 +115,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_INPUT_GENERATOR_REPEAT_H

--- a/srecord/memory.cc
+++ b/srecord/memory.cc
@@ -518,6 +518,3 @@ srecord::memory::is_well_aligned(unsigned multiple)
     walk(sniffer);
     return sniffer->is_well_aligned();
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/memory.h
+++ b/srecord/memory.h
@@ -324,5 +324,4 @@ bool operator == (const srecord::memory &, const srecord::memory &);
   */
 bool operator != (const srecord::memory &, const srecord::memory &);
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_MEMORY_H

--- a/srecord/memory/chunk.cc
+++ b/srecord/memory/chunk.cc
@@ -178,6 +178,3 @@ srecord::operator != (const srecord::memory_chunk &lhs,
 {
     return !srecord::memory_chunk::equal(lhs, rhs);
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/memory/chunk.h
+++ b/srecord/memory/chunk.h
@@ -158,5 +158,4 @@ bool operator != (const srecord::memory_chunk &, const srecord::memory_chunk &);
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_MEMORY_CHUNK_H

--- a/srecord/memory/walker.cc
+++ b/srecord/memory/walker.cc
@@ -57,6 +57,3 @@ srecord::memory_walker::observe_end(void)
 {
     // Do nothing.
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/memory/walker.h
+++ b/srecord/memory/walker.h
@@ -110,5 +110,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_MEMORY_WALKER_H

--- a/srecord/memory/walker/alignment.cc
+++ b/srecord/memory/walker/alignment.cc
@@ -81,6 +81,3 @@ srecord::memory_walker_alignment::observe_end(void)
     if (data_seen && current_address % multiple != 0)
         well_aligned = false;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/memory/walker/alignment.h
+++ b/srecord/memory/walker/alignment.h
@@ -99,5 +99,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_MEMORY_WALKER_ALIGNMENT_H

--- a/srecord/memory/walker/fletcher16.cc
+++ b/srecord/memory/walker/fletcher16.cc
@@ -59,6 +59,3 @@ srecord::memory_walker_fletcher16::get(void)
 {
     return checksum.get();
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/memory/walker/fletcher16.h
+++ b/srecord/memory/walker/fletcher16.h
@@ -117,5 +117,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_MEMORY_WALKER_FLETCHER16_H

--- a/srecord/memory/walker/fletcher32.cc
+++ b/srecord/memory/walker/fletcher32.cc
@@ -51,5 +51,3 @@ srecord::memory_walker_fletcher32::get()
 {
     return checksum.get();
 }
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/memory/walker/fletcher32.h
+++ b/srecord/memory/walker/fletcher32.h
@@ -84,5 +84,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_MEMORY_WALKER_FLETCHER32_H

--- a/srecord/memory/walker/gcrypt.cc
+++ b/srecord/memory/walker/gcrypt.cc
@@ -48,6 +48,3 @@ srecord::memory_walker_gcrypt::observe(unsigned long, const void *data,
     (void)length;
 #endif
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/memory/walker/gcrypt.h
+++ b/srecord/memory/walker/gcrypt.h
@@ -96,5 +96,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_MEMORY_WALKER_GCRYPT_H

--- a/srecord/memory/walker/stm32.cc
+++ b/srecord/memory/walker/stm32.cc
@@ -64,6 +64,3 @@ srecord::memory_walker_stm32::get(void)
 {
     return checksum.get();
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/memory/walker/stm32.h
+++ b/srecord/memory/walker/stm32.h
@@ -96,5 +96,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_MEMORY_WALKER_STM32_H

--- a/srecord/output/file.cc
+++ b/srecord/output/file.cc
@@ -507,6 +507,3 @@ srecord::output_file::data_address_too_large(const srecord::record &record,
     }
     fatal_error("data address (0x%lX..0x%lX) too large", lo, hi);
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/output/file.h
+++ b/srecord/output/file.h
@@ -450,5 +450,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_OUTPUT_FILE_H

--- a/srecord/output/file/aomf.cc
+++ b/srecord/output/file/aomf.cc
@@ -204,6 +204,3 @@ srecord::output_file_aomf::format_name()
 {
     return "AOMF";
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/output/file/aomf.h
+++ b/srecord/output/file/aomf.h
@@ -138,5 +138,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_OUTPUT_FILE_AOMF_H

--- a/srecord/output/file/atmel_generic.cc
+++ b/srecord/output/file/atmel_generic.cc
@@ -120,6 +120,3 @@ srecord::output_file_atmel_generic::format_name()
 {
     return "Atmel-Generic";
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/output/file/brecord.cc
+++ b/srecord/output/file/brecord.cc
@@ -116,6 +116,3 @@ srecord::output_file_brecord::format_name()
 {
     return "B-Record";
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/output/file/brecord.h
+++ b/srecord/output/file/brecord.h
@@ -100,5 +100,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_OUTPUT_FILE_BRECORD_H

--- a/srecord/output/file/c.cc
+++ b/srecord/output/file/c.cc
@@ -809,5 +809,3 @@ srecord::output_file_c::format_name()
 {
     return (output_word ? "C-Array (16-bit)" : "C-Array (8-bit)");
 }
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/output/file/c.h
+++ b/srecord/output/file/c.h
@@ -233,5 +233,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_OUTPUT_FILE_C_H

--- a/srecord/output/file/coe.cc
+++ b/srecord/output/file/coe.cc
@@ -292,6 +292,3 @@ srecord::output_file_coe::format_name(void)
 {
     return "Coefficient (.COE) Files (Xilinx)";
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/output/file/coe.h
+++ b/srecord/output/file/coe.h
@@ -166,5 +166,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_OUTPUT_FILE_COE_H

--- a/srecord/output/file/dec_binary.cc
+++ b/srecord/output/file/dec_binary.cc
@@ -197,6 +197,3 @@ srecord::output_file_dec_binary::is_binary(void)
 {
     return true;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/output/file/dec_binary.h
+++ b/srecord/output/file/dec_binary.h
@@ -128,5 +128,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_OUTPUT_FILE_DEC_BINARY_H

--- a/srecord/output/file/emon52.cc
+++ b/srecord/output/file/emon52.cc
@@ -142,6 +142,3 @@ srecord::output_file_emon52::format_name()
 {
     return "Emon52";
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/output/file/forth.cc
+++ b/srecord/output/file/forth.cc
@@ -157,6 +157,3 @@ srecord::output_file_forth::preferred_block_size_get() const
 {
   return 16;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/output/file/hexdump.h
+++ b/srecord/output/file/hexdump.h
@@ -158,5 +158,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_OUTPUT_FILE_HEXDUMP_H

--- a/srecord/output/file/idt.cc
+++ b/srecord/output/file/idt.cc
@@ -241,6 +241,3 @@ srecord::output_file_idt::is_binary(void)
 {
     return true;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/output/file/idt.h
+++ b/srecord/output/file/idt.h
@@ -157,5 +157,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_OUTPUT_FILE_IDT_H

--- a/srecord/output/file/intel.cc
+++ b/srecord/output/file/intel.cc
@@ -279,6 +279,3 @@ srecord::output_file_intel::format_name()
 {
     return "Intel-Hex";
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/output/file/intel16.cc
+++ b/srecord/output/file/intel16.cc
@@ -202,6 +202,3 @@ srecord::output_file_intel16::format_name()
 {
     return "Intel-16";
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/output/file/logisim.cc
+++ b/srecord/output/file/logisim.cc
@@ -177,6 +177,3 @@ srecord::output_file_logisim::format_name(void)
 {
     return "Logisim";
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/output/file/logisim.h
+++ b/srecord/output/file/logisim.h
@@ -98,5 +98,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_OUTPUT_FILE_LOGISIM_H

--- a/srecord/output/file/mem.cc
+++ b/srecord/output/file/mem.cc
@@ -310,6 +310,3 @@ srecord::output_file_mem::format_name(void)
 {
     return "Lattice Memory Initialization Format (.mem)";
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/output/file/mem.h
+++ b/srecord/output/file/mem.h
@@ -158,5 +158,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_OUTPUT_FILE_MEM_H

--- a/srecord/output/file/mif.h
+++ b/srecord/output/file/mif.h
@@ -145,5 +145,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_OUTPUT_FILE_MIF_H

--- a/srecord/output/file/mips_flash.cc
+++ b/srecord/output/file/mips_flash.cc
@@ -279,6 +279,3 @@ srecord::output_file_mips_flash::format_name(void)
             "MIPS-Flash (little-endian)"
         );
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/output/file/mips_flash.h
+++ b/srecord/output/file/mips_flash.h
@@ -179,5 +179,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_OUTPUT_FILE_MIPS_FLASH_H

--- a/srecord/output/file/mos_tech.cc
+++ b/srecord/output/file/mos_tech.cc
@@ -159,6 +159,3 @@ srecord::output_file_mos_tech::format_name()
 {
     return "MOS-Tech";
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/output/file/ppb.cc
+++ b/srecord/output/file/ppb.cc
@@ -191,6 +191,3 @@ srecord::output_file_ppb::is_binary(void)
 {
     return true;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/output/file/ppb.h
+++ b/srecord/output/file/ppb.h
@@ -144,5 +144,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_OUTPUT_FILE_PPB_H

--- a/srecord/output/file/ppx.cc
+++ b/srecord/output/file/ppx.cc
@@ -172,6 +172,3 @@ srecord::output_file_ppx::format_name(void)
 {
     return "Stag Prom Programmer Hexadecimal";
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/output/file/ppx.h
+++ b/srecord/output/file/ppx.h
@@ -123,5 +123,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_OUTPUT_FILE_PPX_H

--- a/srecord/output/file/signetics.cc
+++ b/srecord/output/file/signetics.cc
@@ -155,6 +155,3 @@ srecord::output_file_signetics::format_name()
 {
     return "Signetics";
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/output/file/spasm.cc
+++ b/srecord/output/file/spasm.cc
@@ -121,6 +121,3 @@ srecord::output_file_spasm::format_name()
 {
     return "Spasm";
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/output/file/stewie.cc
+++ b/srecord/output/file/stewie.cc
@@ -240,6 +240,3 @@ srecord::output_file_stewie::format_name()
 {
     return "Stewie";
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/output/file/tektronix.cc
+++ b/srecord/output/file/tektronix.cc
@@ -203,6 +203,3 @@ srecord::output_file_tektronix::format_name()
 {
     return "Tektronix";
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/output/file/tektronix_extended.cc
+++ b/srecord/output/file/tektronix_extended.cc
@@ -219,6 +219,3 @@ srecord::output_file_tektronix_extended::format_name()
 {
     return "Tektronix-Extended";
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/output/file/ti_tagged.cc
+++ b/srecord/output/file/ti_tagged.cc
@@ -202,6 +202,3 @@ srecord::output_file_ti_tagged::format_name()
 {
     return "TI-Tagged";
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/output/file/ti_tagged_16.cc
+++ b/srecord/output/file/ti_tagged_16.cc
@@ -210,6 +210,3 @@ srecord::output_file_ti_tagged_16::format_name()
 {
     return "TI-Tagged-16";
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/output/file/ti_tagged_16.h
+++ b/srecord/output/file/ti_tagged_16.h
@@ -134,5 +134,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_OUTPUT_FILE_TI_TAGGED_16_H

--- a/srecord/output/file/trs80.cc
+++ b/srecord/output/file/trs80.cc
@@ -163,6 +163,3 @@ srecord::output_file_trs80::is_binary(void)
 {
     return true;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/output/file/trs80.h
+++ b/srecord/output/file/trs80.h
@@ -136,5 +136,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_OUTPUT_FILE_TRS80_H

--- a/srecord/output/file/wilson.cc
+++ b/srecord/output/file/wilson.cc
@@ -232,6 +232,3 @@ srecord::output_file_wilson::is_binary(void)
 {
     return true;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/output/filter.cc
+++ b/srecord/output/filter.cc
@@ -94,6 +94,3 @@ srecord::output_filter::command_line(arglex_tool *cmdln)
 {
     deeper->command_line(cmdln);
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/output/filter.h
+++ b/srecord/output/filter.h
@@ -99,5 +99,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_OUTPUT_FILTER_H

--- a/srecord/output/filter/reblock.cc
+++ b/srecord/output/filter/reblock.cc
@@ -197,6 +197,3 @@ srecord::output_filter_reblock::flush_buffer(bool partial)
         memmove(buffer, buffer + p, buffer_pos);
     }
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/output/filter/reblock.h
+++ b/srecord/output/filter/reblock.h
@@ -168,5 +168,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_OUTPUT_FILTER_REBLOCK_H

--- a/srecord/pretty_size.h
+++ b/srecord/pretty_size.h
@@ -41,5 +41,4 @@ std::string pretty_size(long long x, int width = 0);
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_PRETTY_SIZE_H

--- a/srecord/sizeof.h
+++ b/srecord/sizeof.h
@@ -23,5 +23,4 @@
 #define SIZEOF(a) (sizeof(a) / sizeof(a[0]))
 #define ENDOF(a) ((a) + SIZEOF(a))
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_SIZEOF_H

--- a/srecord/srecord.h
+++ b/srecord/srecord.h
@@ -151,5 +151,4 @@
 #include <srecord/quit/prefix.h>
 #include <srecord/record.h>
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_SRECORD_H

--- a/srecord/stm32.cc
+++ b/srecord/stm32.cc
@@ -135,6 +135,3 @@ srecord::stm32::get(void)
 {
     return state;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/stm32.h
+++ b/srecord/stm32.h
@@ -111,5 +111,4 @@ private:
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_CRC32_H

--- a/srecord/string.h
+++ b/srecord/string.h
@@ -39,5 +39,4 @@ std::string string_quote_c(const std::string &text);
 
 };
 
-// vim: set ts=8 sw=4 et :
 #endif // SRECORD_STRING_H

--- a/srecord/string/quote_c.cc
+++ b/srecord/string/quote_c.cc
@@ -68,6 +68,3 @@ srecord::string_quote_c(const std::string &arg)
         }
     }
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/string/url_decode.cc
+++ b/srecord/string/url_decode.cc
@@ -96,6 +96,3 @@ srecord::string_url_decode(const std::string &text)
     }
     return result.str();
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/srecord/string/url_encode.cc
+++ b/srecord/string/url_encode.cc
@@ -66,6 +66,3 @@ srecord::string_url_encode(const std::string &text)
     }
     return result.str();
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/test/00/t0009a.sh
+++ b/test/00/t0009a.sh
@@ -66,4 +66,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-# vim: set ts=8 sw=4 et :

--- a/test/00/t0013a.sh
+++ b/test/00/t0013a.sh
@@ -63,4 +63,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-# vim: set ts=8 sw=4 et :

--- a/test/00/t0015a.sh
+++ b/test/00/t0015a.sh
@@ -63,4 +63,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-# vim: set ts=8 sw=4 et :

--- a/test/00/t0016a.sh
+++ b/test/00/t0016a.sh
@@ -63,4 +63,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-# vim: set ts=8 sw=4 et :

--- a/test/00/t0031a.sh
+++ b/test/00/t0031a.sh
@@ -51,4 +51,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-# vim: set ts=8 sw=4 et :

--- a/test/00/t0037a.sh
+++ b/test/00/t0037a.sh
@@ -44,4 +44,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-# vim: set ts=8 sw=4 et :

--- a/test/00/t0037b.sh
+++ b/test/00/t0037b.sh
@@ -49,5 +49,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/00/t0039a.sh
+++ b/test/00/t0039a.sh
@@ -92,5 +92,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/00/t0050a.sh
+++ b/test/00/t0050a.sh
@@ -62,4 +62,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-# vim: set ts=8 sw=4 et :

--- a/test/00/t0051a.sh
+++ b/test/00/t0051a.sh
@@ -62,4 +62,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-# vim: set ts=8 sw=4 et :

--- a/test/00/t0053a.sh
+++ b/test/00/t0053a.sh
@@ -48,4 +48,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-# vim: set ts=8 sw=4 et :

--- a/test/00/t0055a.sh
+++ b/test/00/t0055a.sh
@@ -48,4 +48,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-# vim: set ts=8 sw=4 et :

--- a/test/00/t0058a.sh
+++ b/test/00/t0058a.sh
@@ -40,4 +40,3 @@ if test $? -ne 0; then cat LOG; fail; fi
 # No other guarantees are made.
 #
 pass
-# vim: set ts=8 sw=4 et :

--- a/test/00/t0075a.sh
+++ b/test/00/t0075a.sh
@@ -884,4 +884,3 @@ if test $? -ne 0; then cat LOG; fail; fi
 # No other guarantees are made.
 #
 pass
-# vim: set ts=8 sw=4 et :

--- a/test/00/t0089a.sh
+++ b/test/00/t0089a.sh
@@ -144,6 +144,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-
-// vim: set ts=8 sw=4 et :

--- a/test/00/t0092a.sh
+++ b/test/00/t0092a.sh
@@ -79,5 +79,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/00/t0093a.sh
+++ b/test/00/t0093a.sh
@@ -109,5 +109,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0103a.sh
+++ b/test/01/t0103a.sh
@@ -47,4 +47,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0106a.sh
+++ b/test/01/t0106a.sh
@@ -43,5 +43,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0107a.sh
+++ b/test/01/t0107a.sh
@@ -46,5 +46,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0108a.sh
+++ b/test/01/t0108a.sh
@@ -52,5 +52,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0110a.sh
+++ b/test/01/t0110a.sh
@@ -63,5 +63,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0111a.sh
+++ b/test/01/t0111a.sh
@@ -51,5 +51,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0112a.sh
+++ b/test/01/t0112a.sh
@@ -51,5 +51,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0113a.sh
+++ b/test/01/t0113a.sh
@@ -52,5 +52,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0115a.sh
+++ b/test/01/t0115a.sh
@@ -71,5 +71,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0116a.sh
+++ b/test/01/t0116a.sh
@@ -71,5 +71,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0117a.sh
+++ b/test/01/t0117a.sh
@@ -67,5 +67,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0118a.sh
+++ b/test/01/t0118a.sh
@@ -67,5 +67,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0119a.sh
+++ b/test/01/t0119a.sh
@@ -55,5 +55,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0120a.sh
+++ b/test/01/t0120a.sh
@@ -51,5 +51,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0121a.sh
+++ b/test/01/t0121a.sh
@@ -82,5 +82,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0122a.sh
+++ b/test/01/t0122a.sh
@@ -226,5 +226,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0123a.sh
+++ b/test/01/t0123a.sh
@@ -39,5 +39,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0125a.sh
+++ b/test/01/t0125a.sh
@@ -42,5 +42,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0126a.sh
+++ b/test/01/t0126a.sh
@@ -43,5 +43,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0127a.sh
+++ b/test/01/t0127a.sh
@@ -44,5 +44,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0128a.sh
+++ b/test/01/t0128a.sh
@@ -90,5 +90,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0129a.sh
+++ b/test/01/t0129a.sh
@@ -47,5 +47,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0130a.sh
+++ b/test/01/t0130a.sh
@@ -47,5 +47,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0131a.sh
+++ b/test/01/t0131a.sh
@@ -47,5 +47,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0132a.sh
+++ b/test/01/t0132a.sh
@@ -47,5 +47,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0133a.sh
+++ b/test/01/t0133a.sh
@@ -47,5 +47,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0135a.sh
+++ b/test/01/t0135a.sh
@@ -47,5 +47,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0136a.sh
+++ b/test/01/t0136a.sh
@@ -47,5 +47,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0137a.sh
+++ b/test/01/t0137a.sh
@@ -47,5 +47,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0138a.sh
+++ b/test/01/t0138a.sh
@@ -95,5 +95,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0150a.sh
+++ b/test/01/t0150a.sh
@@ -78,5 +78,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0151a.sh
+++ b/test/01/t0151a.sh
@@ -78,5 +78,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0152a.sh
+++ b/test/01/t0152a.sh
@@ -78,5 +78,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0153a.sh
+++ b/test/01/t0153a.sh
@@ -203,5 +203,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0155a.sh
+++ b/test/01/t0155a.sh
@@ -46,5 +46,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0156a.sh
+++ b/test/01/t0156a.sh
@@ -53,5 +53,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0157a.sh
+++ b/test/01/t0157a.sh
@@ -137,5 +137,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0158a.sh
+++ b/test/01/t0158a.sh
@@ -50,5 +50,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0160a.sh
+++ b/test/01/t0160a.sh
@@ -49,5 +49,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0161a.sh
+++ b/test/01/t0161a.sh
@@ -142,5 +142,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0162a.sh
+++ b/test/01/t0162a.sh
@@ -44,5 +44,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0163a.sh
+++ b/test/01/t0163a.sh
@@ -42,5 +42,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0165a.sh
+++ b/test/01/t0165a.sh
@@ -60,5 +60,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0166a.sh
+++ b/test/01/t0166a.sh
@@ -56,5 +56,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0167a.sh
+++ b/test/01/t0167a.sh
@@ -59,5 +59,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0168a.sh
+++ b/test/01/t0168a.sh
@@ -49,5 +49,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0169a.sh
+++ b/test/01/t0169a.sh
@@ -55,5 +55,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0170a.sh
+++ b/test/01/t0170a.sh
@@ -50,5 +50,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0171a.sh
+++ b/test/01/t0171a.sh
@@ -64,5 +64,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0172a.sh
+++ b/test/01/t0172a.sh
@@ -50,5 +50,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0173a.sh
+++ b/test/01/t0173a.sh
@@ -50,5 +50,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0175a.sh
+++ b/test/01/t0175a.sh
@@ -75,5 +75,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0176a.sh
+++ b/test/01/t0176a.sh
@@ -75,5 +75,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0177a.sh
+++ b/test/01/t0177a.sh
@@ -71,5 +71,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0178a.sh
+++ b/test/01/t0178a.sh
@@ -69,5 +69,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0179a.sh
+++ b/test/01/t0179a.sh
@@ -54,5 +54,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0180a.sh
+++ b/test/01/t0180a.sh
@@ -54,5 +54,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0181a.sh
+++ b/test/01/t0181a.sh
@@ -68,5 +68,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0182a.sh
+++ b/test/01/t0182a.sh
@@ -70,5 +70,3 @@ fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0183a.sh
+++ b/test/01/t0183a.sh
@@ -68,5 +68,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0185a.sh
+++ b/test/01/t0185a.sh
@@ -69,5 +69,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0186a.sh
+++ b/test/01/t0186a.sh
@@ -69,5 +69,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0187a.sh
+++ b/test/01/t0187a.sh
@@ -68,5 +68,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0188a.sh
+++ b/test/01/t0188a.sh
@@ -78,5 +78,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0189a.sh
+++ b/test/01/t0189a.sh
@@ -48,5 +48,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0191a.sh
+++ b/test/01/t0191a.sh
@@ -49,5 +49,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0192a.sh
+++ b/test/01/t0192a.sh
@@ -43,5 +43,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0193a.sh
+++ b/test/01/t0193a.sh
@@ -40,5 +40,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0195a.sh
+++ b/test/01/t0195a.sh
@@ -39,5 +39,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0196a.sh
+++ b/test/01/t0196a.sh
@@ -44,5 +44,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0197a.sh
+++ b/test/01/t0197a.sh
@@ -65,5 +65,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0198a.sh
+++ b/test/01/t0198a.sh
@@ -60,5 +60,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/01/t0199a.sh
+++ b/test/01/t0199a.sh
@@ -43,5 +43,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0200a.sh
+++ b/test/02/t0200a.sh
@@ -55,5 +55,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0201a.sh
+++ b/test/02/t0201a.sh
@@ -46,5 +46,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0202a.sh
+++ b/test/02/t0202a.sh
@@ -44,5 +44,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0203a.sh
+++ b/test/02/t0203a.sh
@@ -44,5 +44,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0205a.sh
+++ b/test/02/t0205a.sh
@@ -91,5 +91,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0206a.sh
+++ b/test/02/t0206a.sh
@@ -52,5 +52,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0207a.sh
+++ b/test/02/t0207a.sh
@@ -36,5 +36,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0209a.sh
+++ b/test/02/t0209a.sh
@@ -52,5 +52,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0210a.sh
+++ b/test/02/t0210a.sh
@@ -79,5 +79,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0211a.sh
+++ b/test/02/t0211a.sh
@@ -81,5 +81,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0212a.sh
+++ b/test/02/t0212a.sh
@@ -45,5 +45,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0213a.sh
+++ b/test/02/t0213a.sh
@@ -56,5 +56,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0215a.sh
+++ b/test/02/t0215a.sh
@@ -49,5 +49,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0216a.sh
+++ b/test/02/t0216a.sh
@@ -1310,5 +1310,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0217a.sh
+++ b/test/02/t0217a.sh
@@ -49,5 +49,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0218a.sh
+++ b/test/02/t0218a.sh
@@ -47,5 +47,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0219a.sh
+++ b/test/02/t0219a.sh
@@ -49,5 +49,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0220a.sh
+++ b/test/02/t0220a.sh
@@ -41,5 +41,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0221a.sh
+++ b/test/02/t0221a.sh
@@ -64,5 +64,3 @@ test $? -eq 0 || fail
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0222a.sh
+++ b/test/02/t0222a.sh
@@ -49,5 +49,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0223a.sh
+++ b/test/02/t0223a.sh
@@ -46,5 +46,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0225a.sh
+++ b/test/02/t0225a.sh
@@ -46,5 +46,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0227a.sh
+++ b/test/02/t0227a.sh
@@ -65,5 +65,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0228a.sh
+++ b/test/02/t0228a.sh
@@ -68,5 +68,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0229a.sh
+++ b/test/02/t0229a.sh
@@ -58,5 +58,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0230a.sh
+++ b/test/02/t0230a.sh
@@ -341,5 +341,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0231a.sh
+++ b/test/02/t0231a.sh
@@ -50,5 +50,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0232a.sh
+++ b/test/02/t0232a.sh
@@ -28,5 +28,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0233a.sh
+++ b/test/02/t0233a.sh
@@ -73,5 +73,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0235a.sh
+++ b/test/02/t0235a.sh
@@ -41,5 +41,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0236a.sh
+++ b/test/02/t0236a.sh
@@ -41,5 +41,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0237a.sh
+++ b/test/02/t0237a.sh
@@ -42,5 +42,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0238a.sh
+++ b/test/02/t0238a.sh
@@ -74,5 +74,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0239a.sh
+++ b/test/02/t0239a.sh
@@ -74,5 +74,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0250a.sh
+++ b/test/02/t0250a.sh
@@ -55,5 +55,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0251a.sh
+++ b/test/02/t0251a.sh
@@ -117,5 +117,3 @@ srec_cmp test.bin -bin test.out -logisim
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0253a.sh
+++ b/test/02/t0253a.sh
@@ -144,5 +144,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0254a.sh
+++ b/test/02/t0254a.sh
@@ -38,5 +38,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0255a.sh
+++ b/test/02/t0255a.sh
@@ -140,5 +140,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0256a.sh
+++ b/test/02/t0256a.sh
@@ -340,5 +340,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0257a.sh
+++ b/test/02/t0257a.sh
@@ -907,5 +907,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/02/t0258a.sh
+++ b/test/02/t0258a.sh
@@ -53,5 +53,3 @@ if test $? -ne 0; then fail; fi
 # No other guarantees are made.
 #
 pass
-
-# vim: set ts=8 sw=4 et :

--- a/test/arglex_ambiguous/main.cc
+++ b/test/arglex_ambiguous/main.cc
@@ -43,6 +43,3 @@ main(int argc, char **argv)
     //
     return 0;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/test/crc16/main.cc
+++ b/test/crc16/main.cc
@@ -148,6 +148,3 @@ main(int argc, char **argv)
         printf("0x%04X\n", check.get());
     return 0;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/test/fletcher16/main.cc
+++ b/test/fletcher16/main.cc
@@ -81,6 +81,3 @@ main(int argc, char **argv)
     }
     return 0;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/test/hyphen/main.cc
+++ b/test/hyphen/main.cc
@@ -189,6 +189,3 @@ main(int argc, char **argv)
     }
     return 0;
 }
-
-
-// vim: set ts=8 sw=4 et :

--- a/test/test_prelude.sh
+++ b/test/test_prelude.sh
@@ -113,4 +113,3 @@ then
         $diffpath --strip-trailing-cr "$@"
     }
 fi
-# vim: set ts=8 sw=4 et :

--- a/test/url_decode/main.cc
+++ b/test/url_decode/main.cc
@@ -146,6 +146,3 @@ main(int argc, char **argv)
 
     return EXIT_SUCCESS;
 }
-
-
-// vim: set ts=8 sw=4 et :


### PR DESCRIPTION
Can automatically configure most IDEs/Editors to use the correct whitespace handling.

Vim is also supported, which makes those comments at the end of every source obsolete.
Shall I remove those?