### PR TITLE
Mostly documentation fixes

### DIFF
--- a/doc/man1/srec_input.1
+++ b/doc/man1/srec_input.1
@@ -218,7 +218,7 @@ See \f[I]srec_ppx\fP(5) for a description of this file format.
 .TP 8n
 \fB\-SIGnetics\fP
 This option says to use the Signetics format.
-See \f[I]srec_spasm\fP(5) for a description of this file format.
+See \f[I]srec_signetics\fP(5) for a description of this file format.
 .TP 8n
 \fB\-SPAsm\fP
 This is a synonym for the \fB\-SPAsm_Big_Endian\fP option.

--- a/doc/man1/srec_input.1
+++ b/doc/man1/srec_input.1
@@ -1227,4 +1227,5 @@ they must each be a separate command line argument,
 they can't be within the text of the preceding or following option,
 and you will need to quote them to get them past the shell,
 as \f[CW]'('\fP and \f[CW]')'\fP.
+.ds n) srec_cat
 .so man1/z_copyright.so

--- a/doc/man1/z_copyright.so
+++ b/doc/man1/z_copyright.so
@@ -32,10 +32,10 @@ Copyright
 The
 .I \*(n)
 program comes with ABSOLUTELY NO WARRANTY;
-for details use the '\fI\*(n) \-VERSion License\fP' command.
+for details use the '\fI\*(n) \-LICense\fP' command.
 This is free software
 and you are welcome to redistribute it under certain conditions;
-for details use the '\fI\*(n) \-VERSion License\fP' command.
+for details use the '\fI\*(n) \-LICense\fP' command.
 .br
 .ne 1i
 .SH MAINTAINER

--- a/doc/man3/srecord.3
+++ b/doc/man3/srecord.3
@@ -19,6 +19,9 @@
 .TH \*(n) 3 SRecord "Reference Manual"
 .SH NAME
 srecord \- library to manipulate EPROM load files
+.if require_index \{
+.XX "srecord(3)" "Library to manipulate EPROM load files"
+.\}
 .SH SYNOPSIS
 #include <srecord/\f[I]name\fP.h>
 .sp

--- a/doc/man3/srecord.3
+++ b/doc/man3/srecord.3
@@ -35,4 +35,5 @@ from the source files, and is available on the Internet at
 .br
 .UR http://srecord.sourceforge.net/srecord/index.html
 .UE
+.ds n) srec_cat
 .so man1/z_copyright.so

--- a/doc/man5/srec_binary.5
+++ b/doc/man5/srec_binary.5
@@ -90,5 +90,5 @@ for a description of the \fB\-unfill\fP filter
 \f[I]srec_examples\fP(1)
 has a section about binary files, and ways of automagically
 offsetting the data back to zero in a single command.
-.ds n) SRrecord
+.ds n) srec_cat
 .so man1/z_copyright.so

--- a/doc/man5/srec_coe.5
+++ b/doc/man5/srec_coe.5
@@ -48,4 +48,5 @@ Binary data stored in this format expand approximately 4 times
 .UR http://www.xilinx.com/support/documentation/sw_manuals/xilinx11/cgn_r_coe_file_syntax.htm
 .UE
 .ne 1i
+.ds n) srec_cat
 .so man1/z_copyright.so

--- a/doc/man5/srec_coe.5
+++ b/doc/man5/srec_coe.5
@@ -15,7 +15,7 @@
 .\" You should have received a copy of the GNU General Public License
 .\" along with this program. If not, see <http://www.gnu.org/licenses/>.
 .\"
-.ds n) srec_coe.5
+.ds n) srec_coe
 .TH \*(n) 5 SRecord "Reference Manual"
 .SH NAME
 srec_coe \- Xilinx Coefficient File Format

--- a/doc/man5/srec_logisim.5
+++ b/doc/man5/srec_logisim.5
@@ -71,4 +71,5 @@ There is no provision for an execution start address.
 .SH SEE ALSO
 .UR http://ozark.hendrix.edu/~burch/logisim/docs/2.3.0/guide/mem/menu.html
 .UE
+.ds n) srec_cat
 .so man1/z_copyright.so

--- a/doc/man5/srec_logisim.5
+++ b/doc/man5/srec_logisim.5
@@ -15,7 +15,7 @@
 .\" You should have received a copy of the GNU General Public License
 .\" along with this program. If not, see <http://www.gnu.org/licenses/>.
 .\"
-.ds n) srec_logisim.5
+.ds n) srec_logisim
 .TH \*(n) 5 SRecord "Reference Manual"
 .SH NAME
 srec_logisim \- format Logisim EPROM load files

--- a/doc/man5/srec_mem.5
+++ b/doc/man5/srec_mem.5
@@ -151,4 +151,5 @@ Width;Linux;Windows
 .SS Byte Order
 This format is implicitly big\[hy]endian.
 Use a \-byte\[hy]swap filter if you need something different.
+.ds n) srec_cat
 .so man1/z_copyright.so

--- a/doc/man5/srec_mif.5
+++ b/doc/man5/srec_mif.5
@@ -207,4 +207,5 @@ the following sources:
 .UR http://www.mil.ufl.edu/4712/docs/mif_help.pdf
 .UE
 .fi
+.ds n) srec_cat
 .so man1/z_copyright.so

--- a/doc/man5/srec_mips_flash.5
+++ b/doc/man5/srec_mips_flash.5
@@ -15,7 +15,7 @@
 .\" You should have received a copy of the GNU General Public License
 .\" along with this program. If not, see <http://www.gnu.org/licenses/>.
 .\"
-.ds n) srec_mips_flash.5
+.ds n) srec_mips_flash
 .TH \*(n) 5 SRecord "Reference Manual"
 .SH NAME
 srec_mips_flash \- MIPS\[hy]Flash file format

--- a/doc/man5/srec_mips_flash.5
+++ b/doc/man5/srec_mips_flash.5
@@ -80,4 +80,3 @@ It contains the data \[lq]Hello, World\[rq] to be loaded at bytes address 0x0000
 .\" ------------------------------------------------------------------------
 .ds n) srec_cat
 .so man1/z_copyright.so
-.so man1/z_copyright.so

--- a/doc/man5/srec_ti_txt.5
+++ b/doc/man5/srec_ti_txt.5
@@ -63,4 +63,5 @@ q
 .UE
 \f[B]Note:\fP the portion which says addresses must be even, and the
 number of data bytes in a section must be even, is wrong.
+.ds n) srec_cat
 .so man1/z_copyright.so

--- a/srecord/arglex.cc
+++ b/srecord/arglex.cc
@@ -686,7 +686,7 @@ void
 srecord::arglex::license(void)
     const
 {
-    help("srecord::license");
+    help("srec_license");
 }
 
 


### PR DESCRIPTION
One exception which is not a documentation fix, but related to it:
The -LICense option (for srec_cat/srec_cmp/srec_info) has been fixed.