### PR TITLE
Fix missing reference to hp64k absolute format in srec_input.5

### DIFF
--- a/doc/man1/srec_input.1
+++ b/doc/man1/srec_input.1
@@ -130,10 +130,16 @@ in the style output by the same option.  This is not an exact reverse
 mapping, because if there are ASCII equivalents on the right hand side,
 these may be confused for data bytes.  Also, it doesn't understand white
 space representing holes in the data in the line.
+.TP 8n
+\fB\-HP64k\fP
+This option says to use the HP64000 absolute data format to read the file.
+See
+.IR \f[I]srec_hp64k\fP(5)
+for a description of this file format.
 .\" ----------  I  ---------------------------------------------------------
 .TP 8n
 \fB\-IDT\fP
-This option says to the the IDT/sim binary format to read the file.
+This option says to use the the IDT/sim binary format to read the file.
 See \f[I]srec_idt\fP(5) for a description of this file format.
 .TP 8n
 \fB\-Intel\fP


### PR DESCRIPTION
Fix omitted reference to the hp64k format in the common srec_input page.