### PR TITLE
MSYS2: install mingw-w64-x86_64-texlive-bin

### DIFF
--- a/doc/etc/BUILDING.man
+++ b/doc/etc/BUILDING.man
@@ -116,6 +116,7 @@ will install updates flagged in the updated database.:
 \f[B] \fP           mingw-w64-x86_64-libgcrypt mingw-w64-x86_64-cmake \\
 \f[B] \fP           mingw-w64-x86_64-graphviz mingw-w64-x86_64-ninja \\
 \f[B] \fP           mingw-w64-x86_64-doxygen mingw-w64-i686-ghostscript \\
+\f[B] \fP           mingw-w64-x86_64-texlive-bin \\
 \f[I]\&...lots of output...\fP
 \f[B]%\fP
 .fi


### PR DESCRIPTION
It provides psselect.exe needed during reference manual PDF creation.

I was surprised that there is no psutils package as in Arch Linux.
Also the psselect version of the MSYS2 package is 1.23 only, Arch Linux psutils offers 2.09.
It seems upstream/maintainer has changed years ago: https://tug.org/pipermail/tex-live/2012-December/032759.html