### PR TITLE
CI: Fail QA on warnings by clang-14 and gcc-11

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -3,8 +3,8 @@ name: QA
 on: [push, pull_request]
 
 jobs:
-  build:
-    name: Check source
+  build-clang:
+    name: Check source with clang
     runs-on: ubuntu-22.04
 
     steps:
@@ -22,20 +22,23 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Configure
+        # cSpell:disable
         env:
           CXX: clang++-14
           CXXFLAGS: >-
             -std=c++11
             -pedantic
+            -Werror
             -Wall
+            -Wextra
           SRecord_CMake_Flags: >-
             -D CMAKE_EXPORT_COMPILE_COMMANDS=ON
-        run: |
-          cmake -G Ninja -S . -B build ${SRecord_CMake_Flags}
+        run: cmake -G Ninja -S . -B build ${SRecord_CMake_Flags}
+        # cSpell:enable
 
       - name: Build
         working-directory: build
-        run: ninja srecord-executables
+        run: ninja -k 0 srecord-executables
 
       - name: Smoke test
         working-directory: build
@@ -52,6 +55,55 @@ jobs:
       - name: clang-tidy
         if: always()
         run: run-clang-tidy-14 -p build
+
+  build-gcc:
+    name: Check source with gcc
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Install prerequisites
+        run: >-
+          sudo apt-get install -y
+          libgcrypt20-dev
+          gcc-11
+          cmake
+          ninja-build
+          doxygen
+          graphviz
+
+      - uses: actions/checkout@v3
+
+      - name: Configure
+        # cSpell:disable
+        env:
+          CXX: g++-11
+          CXXFLAGS: >-
+            -std=c++11
+            -pedantic
+            -Werror
+            -Wall
+            -Wextra
+            -Wno-implicit-fallthrough
+          SRecord_CMake_Flags: >-
+            -D CMAKE_EXPORT_COMPILE_COMMANDS=ON
+        run: cmake -G Ninja -S . -B build ${SRecord_CMake_Flags}
+        # cSpell:enable
+
+      - name: Build
+        working-directory: build
+        run: ninja -k 0 srecord-executables
+
+      - name: Smoke test
+        working-directory: build
+        run: ninja srecord-executables-version
+
+      - name: Build test prerequisites
+        working-directory: build
+        run: ninja prepare-test
+
+      - name: Test
+        working-directory: build
+        run: ctest --output-on-failure --output-junit ctest.junit.xml
 
   docs:
     name: Documentation

--- a/srecord/arglex.cc
+++ b/srecord/arglex.cc
@@ -351,6 +351,7 @@ default:
 }
 
 
+#ifndef NDEBUG // used only inside assert calls
 static bool
 starts_with(const std::string &haystack, const std::string &needle)
 {
@@ -361,6 +362,7 @@ starts_with(const std::string &haystack, const std::string &needle)
             0 == memcmp(haystack.c_str(), needle.c_str(), needle.size())
         );
 }
+#endif
 
 
 static bool

--- a/srecord/input/file/hp64k.cc
+++ b/srecord/input/file/hp64k.cc
@@ -71,7 +71,7 @@ srecord::input_file_hp64k::create(const std::string &a_file_name)
 
 
 void
-srecord::input_file_hp64k::command_line(arglex_tool *cmdln)
+srecord::input_file_hp64k::command_line(arglex_tool *)
 {
     //TODO : possibly different types of header bytes ?
     //TODO : don't expect the redundant recsize field?

--- a/srecord/input/file/logisim.cc
+++ b/srecord/input/file/logisim.cc
@@ -253,7 +253,7 @@ srecord::input_file_logisim::read(class record &rec)
             size_t max_data_size = record::maximum_data_length(address);
             size_t data_size =
                 ((size_t)job.count > max_data_size ? max_data_size : job.count);
-            record::data_t data[data_size];
+            auto data = new record::data_t[data_size];
             memset(data, job.value, data_size);
             rec = record(record::type_data, job.address, data, data_size);
             job.address += data_size;
@@ -262,6 +262,7 @@ srecord::input_file_logisim::read(class record &rec)
             {
                 jobs.push_back(job);
             }
+            delete [] data;
             return true;
         }
         read_inner_job();

--- a/srecord/input/file/msbin.cc
+++ b/srecord/input/file/msbin.cc
@@ -116,13 +116,15 @@ srecord::input_file_msbin::read_file_header(void)
         buff[i] = j;
     }
 
-    static_assert(sizeof(buff) >= sizeof(Magic));
+    static_assert(sizeof(buff) >= sizeof(Magic),
+        "Just to be sure that the buffer is big enough.");
     if (memcmp(Magic, buff, sizeof(Magic)))
     {
         // Ok, there's no magic in the header. But it's optional anyway.
 
         // Fill up to two dwords
-        static_assert(sizeof(buff) == 2 * sizeof(uint32_t));
+        static_assert(sizeof(buff) == 2 * sizeof(uint32_t),
+            "Just to be sure that the buffer size equals two uint32_t.");
         int j = get_char();
         if (j < 0)
             fatal_error("short input file");

--- a/srecord/input/file/msbin.h
+++ b/srecord/input/file/msbin.h
@@ -158,7 +158,8 @@ private:
     void read_file_header(void);
 
     // Just to be sure we can fit uint32_t in address_t.
-    static_assert(sizeof(record::address_t) >= sizeof(uint32_t));
+    static_assert(sizeof(record::address_t) >= sizeof(uint32_t),
+        "Just to be sure we can fit uint32_t in address_t.");
 
     /**
       * The read_dword_le method is used to read a little endian double

--- a/srecord/output/file/aomf.cc
+++ b/srecord/output/file/aomf.cc
@@ -83,10 +83,11 @@ void
 srecord::output_file_aomf::content_record(unsigned long address,
     const unsigned char *data, size_t len)
 {
-    size_t maxlen = 4 * srecord::record::max_data_length;
+    const size_t maxlen = 4 * srecord::record::max_data_length;
+    auto buffer = new unsigned char[maxlen + 3];
+
     while (len > 0)
     {
-        unsigned char buffer[maxlen + 3];
         buffer[0] = address >> 16; // this byte should be zero ;-)
         buffer[1] = address; // "offset" is little-endian
         buffer[2] = address >> 8;
@@ -97,6 +98,8 @@ srecord::output_file_aomf::content_record(unsigned long address,
         data += nbytes;
         len -= nbytes;
     }
+
+    delete [] buffer;
 }
 
 

--- a/srecord/output/file/msbin.cc
+++ b/srecord/output/file/msbin.cc
@@ -118,7 +118,7 @@ srecord::output_file_msbin::write_record_header(uint32_t addr, uint32_t length,
 
 
 void
-srecord::output_file_msbin::write_data(const record &r)
+srecord::output_file_msbin::write_record_data(const record &r)
 {
     const unsigned char *data = r.get_data();
     size_t length = r.get_length();
@@ -163,10 +163,10 @@ srecord::output_file_msbin::flush_pending_records(const record *r)
 
         // write data
         for (it = pending_records.begin(); it != pending_records.end(); ++it)
-            write_data(*(*it));
+            write_record_data(*(*it));
 
         if (r)
-            write_data(*r);
+            write_record_data(*r);
 
         pending_records.clear();
     }

--- a/srecord/output/file/msbin.h
+++ b/srecord/output/file/msbin.h
@@ -147,13 +147,13 @@ private:
     void write_record_header(uint32_t addr, uint32_t length, uint32_t checksum);
 
     /**
-      * The write_data method is used to write the data contained in
+      * The write_record_data method is used to write the data contained in
       * a record to the output.
       *
       * @param r
       *     The record containing the data to be written to output.
       */
-    void write_data(const record &r);
+    void write_record_data(const record &r);
 
     /**
       * The flush_pending_records method is used to write out all the


### PR DESCRIPTION
Fixed most warnings for `-std=c++11 -pedantic -Wall -Wextra`.
Disabled only ` -Wno-implicit-fallthrough` on gcc for now.
info for older gcc, `-pedantic` may throw more messages: gcc-8 doesn't like the extra ; on the end of namespace.

Added a gcc-11 build to QA workflow, enabled `-Werror` for it and clang. Added `-k 0` to ninja call, to keep it compiling all files.

- C99 VLA: I replaced the VLA by new/delete combination, as I have seen this as the solution in other files.
- Unused argument: removing the named argument is the solution in other files.
- write_data: I don't know if these functions have any relation. But renaming it was the easiest solution here. And `write_record_data` matches quite well the function directly about it `write_record_header`.