### PR TITLE
Fix PDF creation with MSYS2

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -151,7 +151,7 @@ add_custom_target(web-site ALL DEPENDS ${WEB_PAGE_OUTPUTS})
 # Reference Manual Components
 set(REF_PARTS ${CMAKE_CURRENT_BINARY_DIR}/etc/ref-parts.so)
 add_custom_command(OUTPUT ${REF_PARTS}
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/script/ref-ptx.sh ${MAN_PAGES} > ${REF_PARTS}
+    COMMAND sh ${CMAKE_CURRENT_SOURCE_DIR}/script/ref-ptx.sh ${MAN_PAGES} > ${REF_PARTS}
     DEPENDS
         ${MAN_PAGES}
         ${CMAKE_CURRENT_SOURCE_DIR}/script/ref-ptx.sh

--- a/etc/configure.cmake
+++ b/etc/configure.cmake
@@ -96,6 +96,10 @@ endif (HAVE_GCRYPT_H)
 
 # ps2pdf used in building the PDF version of the documentation
 find_program(PS2PDF ps2pdf)
+if(WIN32)
+  # Shell script cannot be invoked directly using cmd.exe
+  set(PS2PDF "sh" "${PS2PDF}")
+endif()
 message(STATUS "PS2PDF ${PS2PDF}")
 
 # cygpath used in helping the build run on Windows


### PR DESCRIPTION
There were two little regressions which caused the failed/wrong PDF creation.
CI only builds documentation using Linux in "QA" workflow, maybe it should be extended, @jtxa?