### PR TITLE
CI: Add MSYS2 zip package

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,12 +9,22 @@ max_line_length = 120
 tab_width = 8
 trim_trailing_whitespace = true
 
-[*.{cc,h,h.in}]
-max_line_length = 80
-
 [*.{html,man,so}]
 max_line_length = 400
 
+# Sources
+[*.{cc,h,h.in}]
+max_line_length = 80
+
+# Documentation files processed by groff
+[*.{1,3,5,html,lsm,man,so}]
+end_of_line = lf
+
+# Script files
+[*.{awk,sh}]
+end_of_line = lf
+
+# YAML configuration files
 [*.{yaml,yml,clang-tidy}]
 indent_size = 2
 tab_width = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+# Enable default behaviour
+*       text=auto
+
+# Sources
+*.cc    text diff=cpp
+*.h     text diff=cpp
+*.h.in  text diff=cpp
+
+# Documentation files processed by groff
+*.1     text eol=lf
+*.3     text eol=lf
+*.5     text eol=lf
+*.html  text eol=lf
+*.lsm   text eol=lf
+*.man   text eol=lf
+*.so    text eol=lf
+
+# Script files
+*.awk   text eol=lf
+*.sh    text eol=lf
+
+# Image files
+*.ico   binary
+*.png   binary

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -35,7 +35,10 @@ jobs:
             mingw-w64-${{ matrix.env }}-ninja
             mingw-w64-${{ matrix.env }}-doxygen
             mingw-w64-${{ matrix.env }}-graphviz
+            mingw-w64-${{ matrix.env }}-ghostscript
+            mingw-w64-${{ matrix.env }}-texlive-bin
             diffutils
+            groff
 
       - uses: actions/checkout@v3
 
@@ -57,3 +60,17 @@ jobs:
       - name: Test
         working-directory: build
         run: ctest --output-on-failure --output-junit ctest.junit.xml
+
+      - name: Build all
+        working-directory: build
+        run: ninja
+
+      - name: Create ZIP package
+        working-directory: build
+        run: cpack -G ZIP
+
+      - name: Upload packages
+        uses: actions/upload-artifact@v3
+        with:
+          name: msys2-${{ matrix.env }}-packages
+          path: build/srecord-*.*

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -171,7 +171,7 @@ add_custom_command(OUTPUT ${NEW_CHANGES}
 
 # Transform man page(s) (ie troff format files) into a PDF
 function(add_doc TARGET SOURCE DEPS)
-    add_custom_command(OUTPUT ${TARGET}
+    add_custom_command(OUTPUT ${TARGET}.groff.ps
         COMMAND
             sh ${CMAKE_CURRENT_SOURCE_DIR}/script/groff.sh
             -T ps                  # Output device
@@ -182,22 +182,33 @@ function(add_doc TARGET SOURCE DEPS)
             -I${DocSourcePath}
             -I${DocBinaryPath}
             ${SOURCE}              # Source
-            > ${TARGET}.ps.tmp
-        COMMAND
-            sh ${CMAKE_CURRENT_SOURCE_DIR}/script/page_select.sh
-            ${CMAKE_CURRENT_SOURCE_DIR}/script/page-list.awk
-            ${TARGET}.ps.tmp
-            ${TARGET}.ps
-        COMMAND ${PS2PDF} ${TARGET}.ps ${TARGET}
-        COMMAND rm ${TARGET}.ps ${TARGET}.ps.tmp
+            > ${TARGET}.groff.ps
         DEPENDS
             ${SOURCE}
             ${DEPS}
             ${CMAKE_CURRENT_SOURCE_DIR}/script/groff.sh
+        COMMENT "Building ${TARGET}.groff.ps"
+        VERBATIM)
+
+    add_custom_command(OUTPUT ${TARGET}.ps
+        COMMAND
+            sh ${CMAKE_CURRENT_SOURCE_DIR}/script/page_select.sh
+            ${CMAKE_CURRENT_SOURCE_DIR}/script/page-list.awk
+            ${TARGET}.groff.ps
+            ${TARGET}.ps
+        DEPENDS
+            ${TARGET}.groff.ps
             ${CMAKE_CURRENT_SOURCE_DIR}/script/page_select.sh
             ${CMAKE_CURRENT_SOURCE_DIR}/script/page-list.awk
+        COMMENT "Building ${TARGET}.ps"
+        VERBATIM)
+
+    add_custom_command(OUTPUT ${TARGET}
+        COMMAND ${PS2PDF} ${TARGET}.ps ${TARGET}
+        DEPENDS ${TARGET}.ps
         COMMENT "Building ${TARGET}"
         VERBATIM)
+
     list(APPEND DOC_TARGETS ${TARGET})
     set(DOC_TARGETS ${DOC_TARGETS} PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
As requested by @marcows the documentation should be built on MSYS2 to make sure, that it works in this environment.
The workflow now includes a build `all` after doing the tests.

Packaging the zip and upload it as artifact was added as bonus.
The WIX package had several error messages, so that's out of scope for this PR.

As the documentation build did not work, I first splitted the PDF generation into 3 separate step, to be absolutely sure, that the groff call fails.
The only functional change of that split is, that the groff generated ps file is now kept instead of being deleted.

The observed problem was, that the file to be included by groff/soelim contained the carriage return as part of its filename.
This must be caused by the workflows checkout actions, which most probably uses Git for Windows which does CRLF checkouts by default.

To be independent from user git settings, this PR also includes a `.gitattribute` file that explicitly sets LF eol for all files processed by groff. Also the shell and awk scripts shall use always LF.
Editorconfig has been updated to match that behaviour.