### PR TITLE
CI fix

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -20,6 +20,9 @@ jobs:
           - clang-14
 
     steps:
+      - name: Update system
+        run: sudo apt-get update
+
       - name: Install prerequisites
         run: >-
           sudo apt-get install -y

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -8,6 +8,9 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
+      - name: Update system
+        run: sudo apt-get update
+
       - name: Install prerequisites
         run: >-
           sudo apt-get install -y
@@ -61,6 +64,9 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
+      - name: Update system
+        run: sudo apt-get update
+
       - name: Install prerequisites
         run: >-
           sudo apt-get install -y
@@ -110,6 +116,9 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
+      - name: Update system
+        run: sudo apt-get update
+
       - name: Install prerequisites
         run: >-
           sudo apt-get install -y

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -182,6 +182,7 @@ words:
   - globbing
   - gsub
   - gumph
+  - howto
   - htdocs
   - ifndef
   - incl
@@ -222,6 +223,7 @@ words:
   - PDFEXE
   - pirlen
   - productbuild
+  - progname
   - psselect
   - radixes
   - readmemh

--- a/test/01/t0150a.sh
+++ b/test/01/t0150a.sh
@@ -43,17 +43,17 @@ test $? -eq 0 || no_result
 #
 test_crc16 < zero.length.file > test.out
 test $? -eq 0 || fail
-echo >> test.out
+echo | cat >> test.out
 test $? -eq 0 || no_result
 
 test_crc16 < single.a.file >> test.out
 test $? -eq 0 || fail
-echo >> test.out
+echo | cat >> test.out
 test $? -eq 0 || no_result
 
 test_crc16 < nine.digits.file >> test.out
 test $? -eq 0 || fail
-echo >> test.out
+echo | cat >> test.out
 test $? -eq 0 || no_result
 
 test_crc16 < upper-case-a.256.file >> test.out

--- a/test/01/t0151a.sh
+++ b/test/01/t0151a.sh
@@ -43,17 +43,17 @@ test $? -eq 0 || no_result
 #
 test_crc16 -x < zero.length.file > test.out
 test $? -eq 0 || fail
-echo >> test.out
+echo | cat >> test.out
 test $? -eq 0 || no_result
 
 test_crc16 -x < single.a.file >> test.out
 test $? -eq 0 || fail
-echo >> test.out
+echo | cat >> test.out
 test $? -eq 0 || no_result
 
 test_crc16 -x < nine.digits.file >> test.out
 test $? -eq 0 || fail
-echo >> test.out
+echo | cat >> test.out
 test $? -eq 0 || no_result
 
 test_crc16 -x < upper-case-a.256.file >> test.out

--- a/test/01/t0152a.sh
+++ b/test/01/t0152a.sh
@@ -43,17 +43,17 @@ test $? -eq 0 || no_result
 #
 test_crc16 -a < zero.length.file > test.out
 test $? -eq 0 || fail
-echo >> test.out
+echo | cat >> test.out
 test $? -eq 0 || no_result
 
 test_crc16 -a < single.a.file >> test.out
 test $? -eq 0 || fail
-echo >> test.out
+echo | cat >> test.out
 test $? -eq 0 || no_result
 
 test_crc16 -a < nine.digits.file >> test.out
 test $? -eq 0 || fail
-echo >> test.out
+echo | cat >> test.out
 test $? -eq 0 || no_result
 
 test_crc16 -a < upper-case-a.256.file >> test.out


### PR DESCRIPTION
Updated MegaLinter brings:
- a new ShellCheck, that issues an error: Fixed by modifying a few test shell scripts.
- cSpell filename check: Fixed by added some words as expetions

Linux runners were also failing, but that was only temporarily.
Nonetheless  do an `apt-get update` as advised by the GitHub docs.