### PR TITLE
[bugfix] rounding exception

### DIFF
--- a/doc/dictionaries/names.txt
+++ b/doc/dictionaries/names.txt
@@ -1,6 +1,7 @@
 aefinish
 aenbr
 Alin
+Alling
 Altera
 Anselmi
 AOMF
@@ -84,6 +85,7 @@ netpmb
 Niederstrasser
 Nivas
 NSIS
+oceanofthelost
 opensource
 Ozcelik
 patryks
@@ -105,6 +107,7 @@ rpmbuild
 Sadowski
 Schmitt
 SDSMAC
+Sean
 segfault
 Seitz
 Sergeev

--- a/srecord/arglex/tool/get_number.cc
+++ b/srecord/arglex/tool/get_number.cc
@@ -98,6 +98,10 @@ srecord::arglex_tool::get_number(const char *caption)
     case token_round_down:
         token_next();
         multiple = get_number("-round-down");
+        if (multiple == 0)
+        {
+            fatal_error("-Round_Down value must not be 0");
+        }
         value /= multiple;
         value *= multiple;
         break;
@@ -105,6 +109,10 @@ srecord::arglex_tool::get_number(const char *caption)
     case token_round_up:
         token_next();
         multiple = get_number("-round-up");
+        if (multiple == 0)
+        {
+            fatal_error("-Round_Up value must not be 0");
+        }
         value = (value + multiple - 1) / multiple;
         value *= multiple;
         break;
@@ -112,6 +120,10 @@ srecord::arglex_tool::get_number(const char *caption)
     case token_round_nearest:
         token_next();
         multiple = get_number("-round-nearest");
+        if (multiple == 0)
+        {
+            fatal_error("-Round_Nearest value must not be 0");
+        }
         value = (value + multiple / 2) / multiple;
         value *= multiple;
         break;

--- a/test/02/t0262a.sh
+++ b/test/02/t0262a.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 # srecord - Manipulate EPROM load files
-# Copyright (C) 2014 Markus Heidelberg
+# Copyright (C) 2023 Sean Alling
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,15 +20,15 @@
 TEST_SUBJECT="-Round_Up"
 . test_prelude.sh
 
-cat > test.ok << 'fubar'
-S00600004844521B
-S306FFFFFFFE00FE
-S5030001FB
-fubar
-if test $? -ne 0; then no_result; fi
-
-srec_cat test.in  -offset  - 1 -Round_Up 0 -o test.out
+srec_cat -generate 0 8 -constant 0 -offset - 1 -Round_Up 0 \
+    2> test.out
 
 if test $? -ne 1; then fail; fi
 
-pass
+cat > test.ok << 'fubar'
+srec_cat: -Round_Up value must not be 0
+fubar
+if test $? -ne 0; then no_result; fi
+
+diff -u test.ok test.out
+if test $? -ne 0; then fail; fi

--- a/test/02/t0262a.sh
+++ b/test/02/t0262a.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+#
+# srecord - Manipulate EPROM load files
+# Copyright (C) 2014 Markus Heidelberg
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or (at
+# your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+TEST_SUBJECT="-Round_Up"
+. test_prelude.sh
+
+cat > test.ok << 'fubar'
+S00600004844521B
+S306FFFFFFFE00FE
+S5030001FB
+fubar
+if test $? -ne 0; then no_result; fi
+
+srec_cat test.in  -offset  - 1 -Round_Up 0 -o test.out
+
+if test $? -ne 1; then fail; fi
+
+pass

--- a/test/02/t0263a.sh
+++ b/test/02/t0263a.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 # srecord - Manipulate EPROM load files
-# Copyright (C) 2014 Markus Heidelberg
+# Copyright (C) 2023 Sean Alling
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,16 +20,15 @@
 TEST_SUBJECT="-Round_Down"
 . test_prelude.sh
 
-cat > test.ok << 'fubar'
-S00600004844521B
-S306FFFFFFFE00FE
-S5030001FB
-fubar
-if test $? -ne 0; then no_result; fi
-
-srec_cat test.in  -offset  - 1 -Round_Down 0 -o test.out
+srec_cat -generate 0 8 -constant 0 -offset - 1 -Round_Up 0 \
+    2> test.out
 
 if test $? -ne 1; then fail; fi
 
+cat > test.ok << 'fubar'
+srec_cat: -Round_Up value must not be 0
+fubar
+if test $? -ne 0; then no_result; fi
 
-pass
+diff -u test.ok test.out
+if test $? -ne 0; then fail; fi

--- a/test/02/t0263a.sh
+++ b/test/02/t0263a.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# srecord - Manipulate EPROM load files
+# Copyright (C) 2014 Markus Heidelberg
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or (at
+# your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+TEST_SUBJECT="-Round_Down"
+. test_prelude.sh
+
+cat > test.ok << 'fubar'
+S00600004844521B
+S306FFFFFFFE00FE
+S5030001FB
+fubar
+if test $? -ne 0; then no_result; fi
+
+srec_cat test.in  -offset  - 1 -Round_Down 0 -o test.out
+
+if test $? -ne 1; then fail; fi
+
+
+pass

--- a/test/02/t0264a.sh
+++ b/test/02/t0264a.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# srecord - Manipulate EPROM load files
+# Copyright (C) 2014 Markus Heidelberg
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or (at
+# your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+TEST_SUBJECT="-Round_Nearest"
+. test_prelude.sh
+
+cat > test.ok << 'fubar'
+S00600004844521B
+S306FFFFFFFE00FE
+S5030001FB
+fubar
+if test $? -ne 0; then no_result; fi
+
+srec_cat test.in  -offset  - 1 -Round_Nearest 0 -o test.out
+
+if test $? -ne 1; then fail; fi
+
+
+pass

--- a/test/02/t0264a.sh
+++ b/test/02/t0264a.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 # srecord - Manipulate EPROM load files
-# Copyright (C) 2014 Markus Heidelberg
+# Copyright (C) 2023 Sean Alling
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,16 +20,15 @@
 TEST_SUBJECT="-Round_Nearest"
 . test_prelude.sh
 
-cat > test.ok << 'fubar'
-S00600004844521B
-S306FFFFFFFE00FE
-S5030001FB
-fubar
-if test $? -ne 0; then no_result; fi
-
-srec_cat test.in  -offset  - 1 -Round_Nearest 0 -o test.out
+srec_cat -generate 0 8 -constant 0 -offset - 1 -Round_Nearest 0 \
+    2> test.out
 
 if test $? -ne 1; then fail; fi
 
+cat > test.ok << 'fubar'
+srec_cat: -Round_Nearest value must not be 0
+fubar
+if test $? -ne 0; then no_result; fi
 
-pass
+diff -u test.ok test.out
+if test $? -ne 0; then fail; fi


### PR DESCRIPTION
Fixes a potential floating point bug (Issue #35)  caused by invalid user input.

PR adds three new tests, one per input flag. IN addition, added a check in `get_number.cc` which checks if user has passed a zero to one of the rounding functions. If zero passed, then `fatal_error()` is executed and stops execution of user program.