### PR TITLE
Windows build process was not working

### DIFF
--- a/srecord/arglex.cc
+++ b/srecord/arglex.cc
@@ -19,6 +19,7 @@
 #include <cassert>
 #include <cctype>
 #include <cerrno>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>

--- a/srecord/arglex/abbreviate.cc
+++ b/srecord/arglex/abbreviate.cc
@@ -16,6 +16,8 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //
 
+#include <cstdint>
+
 #include <srecord/arglex.h>
 
 

--- a/srecord/pretty_size.cc
+++ b/srecord/pretty_size.cc
@@ -17,6 +17,7 @@
 // <http://www.gnu.org/licenses/>.
 //
 
+#include <cstdint>
 #include <cstdio>
 
 #include <srecord/pretty_size.h>

--- a/srecord/quit/normal.cc
+++ b/srecord/quit/normal.cc
@@ -17,6 +17,7 @@
 //
 
 #include <cstdarg>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>

--- a/srecord/string/quote_c.cc
+++ b/srecord/string/quote_c.cc
@@ -16,6 +16,8 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //
 
+#include <cstdint>
+
 #include <srecord/string.h>
 
 

--- a/srecord/string/url_decode.cc
+++ b/srecord/string/url_decode.cc
@@ -16,6 +16,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //
 
+#include <cstdint>
 #include <sstream>
 
 #include <srecord/string.h>

--- a/srecord/string/url_encode.cc
+++ b/srecord/string/url_encode.cc
@@ -17,6 +17,7 @@
 //
 
 #include <sstream>
+#include <cstdint>
 #include <cstring>
 
 #include <srecord/string.h>

--- a/test/hyphen/main.cc
+++ b/test/hyphen/main.cc
@@ -16,6 +16,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //
 
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <getopt.h>

--- a/test/url_decode/main.cc
+++ b/test/url_decode/main.cc
@@ -17,6 +17,7 @@
 //
 
 #include <cctype>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>


### PR DESCRIPTION
Windows build process was not working due to some missing includes of cstdint.
Used build environment: Windows10 with MSYS2 MINGW64

include <cstdint> added to some .cc file to fix the compiler errors.