### PR TITLE
cmake: respect explicit install prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,9 +33,9 @@ include(InstallRequiredSystemLibraries)
 include(GNUInstallDirs)
 
 # FHS compliant paths for Linux installation
-if(NOT WIN32 AND CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
-#  set(CMAKE_INSTALL_PREFIX "/opt/${PROJECT_NAME}")
-  set(CMAKE_INSTALL_PREFIX "/usr")
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT
+        AND NOT WIN32 AND CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  set(CMAKE_INSTALL_PREFIX "/usr" CACHE PATH "Install prefix" FORCE)
 endif()
 
 # Pull in the rest of the pieces


### PR DESCRIPTION
If CMAKE_INSTALL_PREFIX was supplied externally, use it.  This follows the pattern suggested by cmake documentation in:
https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT.html

I took the liberty of removing (rather than fixing) the commented out line of code, because that reduces the testing surface I needed to cover.  I hope that is acceptable.

The original motivation for this fix is that srecord is packaged in yocto project's meta-openembedded layer, and its ignoring of the install prefix prevents it from staging correctly into the destination sysroot.

This addresses Issue #65 