### PR TITLE
[WIP] Add simple CMake presets

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -38,19 +38,17 @@ jobs:
       - name: Configure
         run: |
           export CXX=$(echo ${{ matrix.compiler }} | sed -E 's/^(g|clang)(cc)?/\1++/')
-          cmake -G Ninja -S . -B build
+          cmake --preset default --fresh
 
       - name: Build
-        working-directory: build
-        run: ninja srecord-executables
+        run: cmake --build  --preset srecord-executables
 
       - name: Smoke test
-        working-directory: build
-        run: ninja srecord-executables-version
+        run: cmake --build  --preset srecord-executables-version
 
       - name: Build test prerequisites
-        working-directory: build
-        run: ninja prepare-test
+
+        run: cmake --build  --preset prepare-test
 
       - name: Test
         working-directory: build

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -19,19 +19,16 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Configure
-        run: cmake -G Ninja -S . -B build
+        run: cmake --preset default --fresh
 
       - name: Build
-        working-directory: build
-        run: ninja srecord-executables
+        run: cmake --build  --preset srecord-executables
 
       - name: Smoke test
-        working-directory: build
-        run: ninja srecord-executables-version
+        run: cmake --build  --preset srecord-executables-version
 
       - name: Build test prerequisites
-        working-directory: build
-        run: ninja prepare-test
+        run: cmake --build  --preset prepare-test
 
       - name: Test
         working-directory: build

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -43,19 +43,16 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Configure
-        run: cmake -G Ninja -S . -B build
+        run: cmake --preset default --fresh
 
       - name: Build
-        working-directory: build
-        run: ninja srecord-executables
+        run: cmake --build  --preset srecord-executables
 
       - name: Smoke test
-        working-directory: build
-        run: ninja srecord-executables-version
+        run: cmake --build  --preset srecord-executables-version
 
       - name: Build test prerequisites
-        working-directory: build
-        run: ninja prepare-test
+        run: cmake --build  --preset prepare-test
 
       - name: Test
         working-directory: build

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -36,24 +36,22 @@ jobs:
             -Wextra
           SRecord_CMake_Flags: >-
             -D CMAKE_EXPORT_COMPILE_COMMANDS=ON
-        run: cmake -G Ninja -S . -B build ${SRecord_CMake_Flags}
+        run: cmake --preset default --fresh ${SRecord_CMake_Flags}
         # cSpell:enable
 
       - name: Build
-        working-directory: build
         run: ninja -k 0 srecord-executables
 
       - name: Smoke test
-        working-directory: build
-        run: ninja srecord-executables-version
+        run: cmake --build  --preset srecord-executables-version
 
       - name: Build test prerequisites
-        working-directory: build
-        run: ninja prepare-test
+        run: cmake --build  --preset prepare-test
 
       - name: Test
         working-directory: build
         run: ctest --output-on-failure --output-junit ctest.junit.xml
+
 
       - name: clang-tidy
         if: always()
@@ -92,24 +90,22 @@ jobs:
             -Wno-implicit-fallthrough
           SRecord_CMake_Flags: >-
             -D CMAKE_EXPORT_COMPILE_COMMANDS=ON
-        run: cmake -G Ninja -S . -B build ${SRecord_CMake_Flags}
+        run:  cmake --preset default --fresh ${SRecord_CMake_Flags}
         # cSpell:enable
 
       - name: Build
-        working-directory: build
         run: ninja -k 0 srecord-executables
 
       - name: Smoke test
-        working-directory: build
-        run: ninja srecord-executables-version
+        run: cmake --build srecord-executables-version
 
       - name: Build test prerequisites
-        working-directory: build
-        run: ninja prepare-test
+        run: cmake --build prepare-test
 
       - name: Test
         working-directory: build
         run: ctest --output-on-failure --output-junit ctest.junit.xml
+
 
   docs:
     name: Documentation

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,76 @@
+{
+    "version": 6,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 25,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+          "name": "cmake-pedantic",
+          "hidden": true,
+          "warnings": {
+            "dev": false,
+            "uninitialized": false,
+            "systemVars": false
+          },
+          "errors": {
+            "deprecated": true
+          }
+        },
+        {
+          "name": "ci-build",
+          "binaryDir": "${sourceDir}/build",
+          "hidden": true
+        },
+        {
+            "name": "ninja",
+            "generator": "Ninja",
+            "hidden": true
+          },
+        {
+            "name": "default",
+            "displayName": "Basic configuration",
+            "inherits": ["ci-build", "cmake-pedantic", "ninja"]
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "default-config-preset",
+            "hidden": true,
+            "configurePreset": "default"
+        },
+        {
+            "name": "clean",
+            "displayName": "Debug build",
+            "targets" : "clean",
+            "inherits": ["default-config-preset"]
+        },
+        {
+            "name": "srecord-executables",
+            "displayName": "Debug build",
+            "targets" : "srecord-executables",
+            "inherits": ["default-config-preset"]
+        },
+        {
+            "name": "srecord-executables-version",
+            "displayName": "Debug build",
+            "inherits": ["default-config-preset"],
+            "targets" : "srecord-executables-version"
+        },
+        {
+            "name": "prepare-test",
+            "displayName": "Debug build",
+            "inherits": ["default-config-preset"],
+            "targets" : "prepare-test"
+        }
+    ],
+    "testPresets": [
+        {
+            "name": "test",
+            "configurePreset": "default",
+            "output": {"outputOnFailure": true, "outputJUnitFile": "ctest.junit.xml"}
+
+        }
+    ]
+}

--- a/srecord/arglex.cc
+++ b/srecord/arglex.cc
@@ -144,10 +144,10 @@ srecord::arglex::compare(const char *formal, const char *actual)
 {
     for (;;)
     {
-        uint8_t ac = *actual++;
+        std::uint8_t ac = *actual++;
         if (isupper(ac))
             ac = tolower(ac);
-        uint8_t fc = *formal++;
+        std::uint8_t fc = *formal++;
         switch (fc)
         {
         case 0:

--- a/srecord/arglex.cc
+++ b/srecord/arglex.cc
@@ -24,6 +24,7 @@
 #include <cstring>
 #include <iostream>
 #include <unistd.h>
+#include <cstdint>
 
 #include <srecord/arglex.h>
 #include <srecord/progname.h>
@@ -80,7 +81,7 @@ srecord::arglex::read_arguments_file(const char *filename)
         int sc = getc(fp);
         if (sc == EOF)
             break;
-        uint8_t c = sc;
+        std::uint8_t c = sc;
 
         //
         // Ignore white space between words.

--- a/srecord/arglex/abbreviate.cc
+++ b/srecord/arglex/abbreviate.cc
@@ -17,7 +17,7 @@
 //
 
 #include <srecord/arglex.h>
-
+#include <cstdint>
 
 std::string
 srecord::arglex::abbreviate(const char *s)

--- a/srecord/arglex/abbreviate.cc
+++ b/srecord/arglex/abbreviate.cc
@@ -25,7 +25,7 @@ srecord::arglex::abbreviate(const char *s)
     std::string result;
     for (;;)
     {
-        uint8_t c = *s++;
+        std::uint8_t c = *s++;
         switch (c)
         {
         case '\0':

--- a/srecord/input/file/hexdump.cc
+++ b/srecord/input/file/hexdump.cc
@@ -41,7 +41,7 @@ srecord::input_file_hexdump::get_next_token()
         int sc = get_char();
         if (sc < 0)
             return token_eof;
-        uint8_t c = sc;
+        std::uint8_t c = sc;
         switch (c)
         {
         case '\n':

--- a/srecord/input/file/ppx.cc
+++ b/srecord/input/file/ppx.cc
@@ -17,6 +17,7 @@
 //
 
 #include <cassert>
+#include <cstdint>
 
 #include <srecord/arglex/tool.h>
 #include <srecord/input/file/ppx.h>
@@ -47,7 +48,7 @@ srecord::input_file_ppx::get_next_token()
             token = token_eof;
             return;
         }
-        uint8_t c = sc;
+        std::uint8_t c = sc;
         switch (c)
         {
         case '*':


### PR DESCRIPTION
Creating to demo CMake presets. 

Discussion can be found here #70. 

Updated some CI steps to showcase workflows running

> NOTE: Following sections reference deleting build folder. This step can be skipped after running presets the first time. 

## Building

From project root directory
1.  delete `build` folder
2. `cmake --preset default`
3. `cmake --preset build` 

## Running Tests
1. `cmake --preset smoke-test` 
2. `cmake --preset prepare-test` 
3. `ctest ctest --preset test`

## Using a Workflow
A workflow allows running multiple CMake steps back to back automatically

From project root directory
1.  delete `build` folder
2. `cmake --workflow --preset ci`