### PR TITLE
C-array: Add option to set array element size

### DIFF
--- a/doc/man1/srec_cat.1
+++ b/doc/man1/srec_cat.1
@@ -198,9 +198,15 @@ into the read\[hy]only segment in embedded systems).
 These options ask for an compressed c\[hy]array whose memory
 gaps will not be filled.
 .TP 8n
-\fB\-Output_Word\fP
+\fB\-Output_Word\fP [ \f[I]width\fP ]
 This option asks for an output which is in words not in
-bytes.  This is little endian, so you may need to
+bytes.  This is little endian, so you may need to use the \-byte\[hy]swap
+filter to get the byte order you want.
+
+The optional \f[I]width\fP argument sets the number of bytes in each word. If
+width is not specified, this defaults to 2 byte words. If width is specified,
+then the output array will be declared using an appropriate fixed width integer
+type.
 .TP 8n
 \fB\-PREfix\fP \f[I]string\fP
 This option allows a string to be prepended to the array definition. This

--- a/srecord/arglex.cc
+++ b/srecord/arglex.cc
@@ -21,6 +21,7 @@
 #include <cerrno>
 #include <cstdio>
 #include <cstdlib>
+#include <cstdint>
 #include <cstring>
 #include <iostream>
 #include <unistd.h>

--- a/srecord/arglex/abbreviate.cc
+++ b/srecord/arglex/abbreviate.cc
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //
+#include <cstdint>
 
 #include <srecord/arglex.h>
 

--- a/srecord/output/file/c.h
+++ b/srecord/output/file/c.h
@@ -21,6 +21,8 @@
 #ifndef SRECORD_OUTPUT_FILE_C_H
 #define SRECORD_OUTPUT_FILE_C_H
 
+#include <cstdint>
+
 #include <srecord/output/file.h>
 #include <srecord/interval.h>
 
@@ -164,10 +166,34 @@ private:
     std::string include_file_name;
 
     /**
-      * The output_word instance variable is used to remember whether or not
-      * the input bytes should be emitted as word.
+      * The output_type instance variable is used to remember what C data type
+      * the input bytes should be emitted as.
       */
-    bool output_word{false};
+    enum {
+      output_byte,
+      output_unsigned_short,
+      output_uint16_t,
+      output_uint32_t,
+      output_uint64_t,
+    } output_type{output_byte};
+
+    /**
+     * bytes_per_word is a const function that returns how many bytes are in
+     * an output word based on the output_type instance variable.
+     */
+    unsigned bytes_per_word() const;
+
+    /**
+     * output_c_type returns a string that evalutates to the C variable type of
+     * the resulting generated array based on the output_type instance
+     * vairable.
+     */
+    char const * output_c_type() const;
+
+    /**
+     * max_word_value returns an output word with all of the bits set.
+     */
+    uint64_t max_word_value() const;
 
     /**
       * The hex_style instance variable is used to remember whether or
@@ -195,16 +221,10 @@ private:
     void emit_header();
 
     /**
-      * The emit_byte method is used to emit a single byte.  It uses
+      * The emit_word method is used to emit a single word.  It uses
       * column to track the position, so as not to exceed line_length.
       */
-    void emit_byte(int);
-
-    /**
-      * The emit_byte method is used to emit a single byte.  It uses
-      * column to track the position, so as not to exceed line_length.
-      */
-    void emit_word(unsigned int);
+    void emit_word(uint64_t);
 
     /**
       * The format_address method is used to format an address, taking

--- a/srecord/quit/normal.cc
+++ b/srecord/quit/normal.cc
@@ -19,6 +19,7 @@
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
+#include <cstdint>
 #include <cstring>
 #include <iostream>
 

--- a/srecord/string/quote_c.cc
+++ b/srecord/string/quote_c.cc
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //
+#include <cstdint>
 
 #include <srecord/string.h>
 

--- a/srecord/string/url_decode.cc
+++ b/srecord/string/url_decode.cc
@@ -16,6 +16,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //
 
+#include <cstdint>
 #include <sstream>
 
 #include <srecord/string.h>

--- a/srecord/string/url_encode.cc
+++ b/srecord/string/url_encode.cc
@@ -17,6 +17,7 @@
 //
 
 #include <sstream>
+#include <cstdint>
 #include <cstring>
 
 #include <srecord/string.h>

--- a/test/02/t0270a.sh
+++ b/test/02/t0270a.sh
@@ -1,0 +1,224 @@
+#!/bin/sh
+#
+#       srecord - The "srecord" program.
+#       Copyright (C) 2007, 2008, 2011 Peter Miller
+#
+#       This program is free software; you can redistribute it and/or modify
+#       it under the terms of the GNU General Public License as published by
+#       the Free Software Foundation; either version 3 of the License, or
+#       (at your option) any later version.
+#
+#       This program is distributed in the hope that it will be useful,
+#       but WITHOUT ANY WARRANTY; without even the implied warranty of
+#       MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#       GNU General Public License for more details.
+#
+#       You should have received a copy of the GNU General Public License
+#       along with this program. If not, see
+#       <http://www.gnu.org/licenses/>.
+#
+
+TEST_SUBJECT="-c-array -output-word 16"
+. test_prelude.sh
+
+cat > test.in << 'fubar'
+S00600004844521B
+S111000748656C6C6F2C20576F726C64210A74
+S111002048656C6C6F2C20576F726C64210A5B
+S111004248656C6C6F2C20576F726C64210A39
+S5030003F9
+S9030007F5
+fubar
+if test $? -ne 0; then no_result; fi
+
+cat > test.ok << 'fubar'
+/* HDR */
+#include <stdint.h>
+const uint16_t eprom[] =
+{
+0x48FF, 0x6C65, 0x6F6C, 0x202C, 0x6F57, 0x6C72, 0x2164, 0xFF0A, 0x6548,
+0x6C6C, 0x2C6F, 0x5720, 0x726F, 0x646C, 0x0A21, 0x6548, 0x6C6C, 0x2C6F,
+0x5720, 0x726F, 0x646C, 0x0A21,
+};
+
+const unsigned long eprom_address[] =
+{
+0x00000006, 0x00000020, 0x00000042,
+};
+const unsigned long eprom_word_address[] =
+{
+0x00000003, 0x00000010, 0x00000021,
+};
+const unsigned long eprom_length_of_sections[] =
+{
+0x00000008, 0x00000007, 0x00000007,
+};
+const unsigned long eprom_sections    = 0x00000003;
+const unsigned long eprom_termination = 0x00000007;
+const unsigned long eprom_start       = 0x00000006;
+const unsigned long eprom_finish      = 0x00000050;
+const unsigned long eprom_length      = 0x0000004A;
+
+#define EPROM_TERMINATION 0x00000007
+#define EPROM_START       0x00000006
+#define EPROM_FINISH      0x00000050
+#define EPROM_LENGTH      0x0000004A
+#define EPROM_SECTIONS    0x00000003
+fubar
+if test $? -ne 0; then no_result; fi
+
+cat > test.ok.h << 'fubar'
+#ifndef TEST_H
+#define TEST_H
+#include <stdint.h>
+
+extern const unsigned long eprom_termination;
+extern const unsigned long eprom_start;
+extern const unsigned long eprom_finish;
+extern const unsigned long eprom_length;
+extern const unsigned long eprom_sections;
+extern const uint16_t eprom[];
+extern const unsigned long eprom_address[];
+extern const unsigned long eprom_word_address[];
+extern const unsigned long eprom_length_of_sections[];
+
+#endif /* TEST_H */
+fubar
+if test $? -ne 0; then no_result; fi
+
+srec_cat test.in -fill 0xFF -within test.in -range-padding=2 \
+    -o test.out -c-array -section-style -ow 2 -include
+if test $? -ne 0; then fail; fi
+
+diff test.ok test.out
+if test $? -ne 0; then fail; fi
+
+diff test.ok.h test.h
+if test $? -ne 0; then fail; fi
+
+# ---------- one more time, with decimal uint16_t words -----------------------
+
+cat > test.ok << 'fubar'
+/* HDR */
+#include <stdint.h>
+const uint16_t eprom[] =
+{
+18687, 27749, 28524, 8236, 28503, 27762, 8548, 65290, 25928, 27756, 11375,
+22304, 29295, 25708, 2593, 25928, 27756, 11375, 22304, 29295, 25708, 2593,
+};
+
+const unsigned long eprom_address[] =
+{
+6, 32, 66,
+};
+const unsigned long eprom_word_address[] =
+{
+3, 16, 33,
+};
+const unsigned long eprom_length_of_sections[] =
+{
+8, 7, 7,
+};
+const unsigned long eprom_sections    = 3;
+const unsigned long eprom_termination = 7;
+const unsigned long eprom_start       = 6;
+const unsigned long eprom_finish      = 80;
+const unsigned long eprom_length      = 74;
+
+#define EPROM_TERMINATION 7
+#define EPROM_START       6
+#define EPROM_FINISH      80
+#define EPROM_LENGTH      74
+#define EPROM_SECTIONS    3
+fubar
+if test $? -ne 0; then no_result; fi
+
+srec_cat test.in -fill 0xFF -within test.in -range-padding=2 \
+    -o test.out -c-array -section-style -ow 2 -dec-style
+if test $? -ne 0; then fail; fi
+
+diff test.ok test.out
+if test $? -ne 0; then fail; fi
+
+# ---------- --output-word 2 is equivalent to -output-word 16 -----------------
+
+srec_cat test.in -fill 0xFF -within test.in -range-padding=2 \
+    -o test.out -c-array -section-style -ow 16 -dec-style
+if test $? -ne 0; then fail; fi
+
+diff test.ok test.out
+if test $? -ne 0; then fail; fi
+
+# ---------- one more time, with byte swapped input ---------------------------
+
+cat > test.ok << 'fubar'
+/* 00000001: HDR */
+#include <stdint.h>
+const uint16_t eprom[] =
+{
+0xFF48, 0x656C, 0x6C6F, 0x2C20, 0x576F, 0x726C, 0x6421, 0x0AFF, 0x4865,
+0x6C6C, 0x6F2C, 0x2057, 0x6F72, 0x6C64, 0x210A, 0x4865, 0x6C6C, 0x6F2C,
+0x2057, 0x6F72, 0x6C64, 0x210A,
+};
+
+const unsigned long eprom_address[] =
+{
+0x00000006, 0x00000020, 0x00000042,
+};
+const unsigned long eprom_word_address[] =
+{
+0x00000003, 0x00000010, 0x00000021,
+};
+const unsigned long eprom_length_of_sections[] =
+{
+0x00000008, 0x00000007, 0x00000007,
+};
+const unsigned long eprom_sections    = 0x00000003;
+const unsigned long eprom_termination = 0x00000006;
+const unsigned long eprom_start       = 0x00000006;
+const unsigned long eprom_finish      = 0x00000050;
+const unsigned long eprom_length      = 0x0000004A;
+
+#define EPROM_TERMINATION 0x00000006
+#define EPROM_START       0x00000006
+#define EPROM_FINISH      0x00000050
+#define EPROM_LENGTH      0x0000004A
+#define EPROM_SECTIONS    0x00000003
+fubar
+if test $? -ne 0; then no_result; fi
+
+srec_cat test.in -fill 0xFF -within test.in -range-padding=2 -byte-swap 2 \
+    -o test.out -c-array -section-style -ow 2
+if test $? -ne 0; then fail; fi
+
+diff test.ok test.out
+if test $? -ne 0; then fail; fi
+
+# ---------- Fatal alignment error --------------------------------------------
+cat > test.in << 'fubar'
+S0220000687474703A2F2F737265636F72642E736F75726365666F7267652E6E65742F1D
+S1230001000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1FEB
+S5030001FB
+S9030001FB
+fubar
+if test $? -ne 0; then no_result; fi
+
+cat > test.ok << 'fubar'
+srec_cat: test.out: 5: The C-Array (uint16_t) output format uses 16-bit data,
+    but unaligned data is present. Use a "--fill 0xNN --within <input>
+    --range-padding 2" filter to fix this problem.
+fubar
+
+srec_cat test.in  -o test.out -c-array -ow 2  > LOG 2>&1
+if test $? -ne 1; then
+    cat LOG
+    fail
+fi
+diff test.ok LOG
+if test $? -ne 0; then fail; fi
+
+#
+# The things tested here, worked.
+# No other guarantees are made.
+#
+pass

--- a/test/02/t0271a.sh
+++ b/test/02/t0271a.sh
@@ -1,0 +1,225 @@
+#!/bin/sh
+#
+#       srecord - The "srecord" program.
+#       Copyright (C) 2007, 2008, 2011 Peter Miller
+#
+#       This program is free software; you can redistribute it and/or modify
+#       it under the terms of the GNU General Public License as published by
+#       the Free Software Foundation; either version 3 of the License, or
+#       (at your option) any later version.
+#
+#       This program is distributed in the hope that it will be useful,
+#       but WITHOUT ANY WARRANTY; without even the implied warranty of
+#       MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#       GNU General Public License for more details.
+#
+#       You should have received a copy of the GNU General Public License
+#       along with this program. If not, see
+#       <http://www.gnu.org/licenses/>.
+#
+
+TEST_SUBJECT="-c-array -output-word 32"
+. test_prelude.sh
+
+cat > test.in << 'fubar'
+S00600004844521B
+S111000748656C6C6F2C20576F726C64210A74
+S111002048656C6C6F2C20576F726C64210A5B
+S111004248656C6C6F2C20576F726C64210A39
+S5030003F9
+S9030007F5
+fubar
+if test $? -ne 0; then no_result; fi
+
+cat > test.ok << 'fubar'
+/* HDR */
+#include <stdint.h>
+const uint32_t eprom[] =
+{
+0x48FFFFFF, 0x6F6C6C65, 0x6F57202C, 0x21646C72, 0xFFFFFF0A, 0x6C6C6548,
+0x57202C6F, 0x646C726F, 0xFFFF0A21, 0x6548FFFF, 0x2C6F6C6C, 0x726F5720,
+0x0A21646C,
+};
+
+const unsigned long eprom_address[] =
+{
+0x00000004, 0x00000020, 0x00000040,
+};
+const unsigned long eprom_word_address[] =
+{
+0x00000001, 0x00000008, 0x00000010,
+};
+const unsigned long eprom_length_of_sections[] =
+{
+0x00000005, 0x00000004, 0x00000004,
+};
+const unsigned long eprom_sections    = 0x00000003;
+const unsigned long eprom_termination = 0x00000007;
+const unsigned long eprom_start       = 0x00000004;
+const unsigned long eprom_finish      = 0x00000050;
+const unsigned long eprom_length      = 0x0000004C;
+
+#define EPROM_TERMINATION 0x00000007
+#define EPROM_START       0x00000004
+#define EPROM_FINISH      0x00000050
+#define EPROM_LENGTH      0x0000004C
+#define EPROM_SECTIONS    0x00000003
+fubar
+if test $? -ne 0; then no_result; fi
+
+cat > test.ok.h << 'fubar'
+#ifndef TEST_H
+#define TEST_H
+#include <stdint.h>
+
+extern const unsigned long eprom_termination;
+extern const unsigned long eprom_start;
+extern const unsigned long eprom_finish;
+extern const unsigned long eprom_length;
+extern const unsigned long eprom_sections;
+extern const uint32_t eprom[];
+extern const unsigned long eprom_address[];
+extern const unsigned long eprom_word_address[];
+extern const unsigned long eprom_length_of_sections[];
+
+#endif /* TEST_H */
+fubar
+if test $? -ne 0; then no_result; fi
+
+srec_cat test.in -fill 0xFF -within test.in -range-padding=4 \
+    -o test.out -c-array -section-style -ow 4 -include
+if test $? -ne 0; then fail; fi
+
+diff test.ok test.out
+if test $? -ne 0; then fail; fi
+
+diff test.ok.h test.h
+if test $? -ne 0; then fail; fi
+
+# ---------- one more time, with decimal uint32_t words -----------------------
+
+cat > test.ok << 'fubar'
+/* HDR */
+#include <stdint.h>
+const uint32_t eprom[] =
+{
+1224736767, 1869376613, 1867980844, 560229490, 4294967050, 1819043144,
+1461726319, 1684828783, 4294904353, 1699282943, 745499756, 1919899424,
+169960556,
+};
+
+const unsigned long eprom_address[] =
+{
+4, 32, 64,
+};
+const unsigned long eprom_word_address[] =
+{
+1, 8, 16,
+};
+const unsigned long eprom_length_of_sections[] =
+{
+5, 4, 4,
+};
+const unsigned long eprom_sections    = 3;
+const unsigned long eprom_termination = 7;
+const unsigned long eprom_start       = 4;
+const unsigned long eprom_finish      = 80;
+const unsigned long eprom_length      = 76;
+
+#define EPROM_TERMINATION 7
+#define EPROM_START       4
+#define EPROM_FINISH      80
+#define EPROM_LENGTH      76
+#define EPROM_SECTIONS    3
+fubar
+if test $? -ne 0; then no_result; fi
+
+srec_cat test.in -fill 0xFF -within test.in -range-padding=4 \
+    -o test.out -c-array -section-style -ow 4 -dec-style
+if test $? -ne 0; then fail; fi
+
+diff test.ok test.out
+if test $? -ne 0; then fail; fi
+
+# ---------- --output-word 4 is equivalent to -output-word 32 -----------------
+
+srec_cat test.in -fill 0xFF -within test.in -range-padding=4 \
+    -o test.out -c-array -section-style -ow 32 -dec-style
+if test $? -ne 0; then fail; fi
+
+diff test.ok test.out
+if test $? -ne 0; then fail; fi
+
+# ---------- one more time, with byte swapped input ---------------------------
+
+cat > test.ok << 'fubar'
+/* 00000003: HDR */
+#include <stdint.h>
+const uint32_t eprom[] =
+{
+0xFFFFFF48, 0x656C6C6F, 0x2C20576F, 0x726C6421, 0x0AFFFFFF, 0x48656C6C,
+0x6F2C2057, 0x6F726C64, 0x210AFFFF, 0xFFFF4865, 0x6C6C6F2C, 0x20576F72,
+0x6C64210A,
+};
+
+const unsigned long eprom_address[] =
+{
+0x00000004, 0x00000020, 0x00000040,
+};
+const unsigned long eprom_word_address[] =
+{
+0x00000001, 0x00000008, 0x00000010,
+};
+const unsigned long eprom_length_of_sections[] =
+{
+0x00000005, 0x00000004, 0x00000004,
+};
+const unsigned long eprom_sections    = 0x00000003;
+const unsigned long eprom_termination = 0x00000004;
+const unsigned long eprom_start       = 0x00000004;
+const unsigned long eprom_finish      = 0x00000050;
+const unsigned long eprom_length      = 0x0000004C;
+
+#define EPROM_TERMINATION 0x00000004
+#define EPROM_START       0x00000004
+#define EPROM_FINISH      0x00000050
+#define EPROM_LENGTH      0x0000004C
+#define EPROM_SECTIONS    0x00000003
+fubar
+if test $? -ne 0; then no_result; fi
+
+srec_cat test.in -fill 0xFF -within test.in -range-padding=4 -byte-swap 4 \
+    -o test.out -c-array -section-style -ow 4
+if test $? -ne 0; then fail; fi
+
+diff test.ok test.out
+if test $? -ne 0; then fail; fi
+
+# ---------- Fatal alignment error --------------------------------------------
+cat > test.in << 'fubar'
+S0220000687474703A2F2F737265636F72642E736F75726365666F7267652E6E65742F1D
+S1230002000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1FEA
+S5030001FB
+S9030001FB
+fubar
+if test $? -ne 0; then no_result; fi
+
+cat > test.ok << 'fubar'
+srec_cat: test.out: 5: The C-Array (uint32_t) output format uses 32-bit data,
+    but unaligned data is present. Use a "--fill 0xNN --within <input>
+    --range-padding 4" filter to fix this problem.
+fubar
+
+srec_cat test.in  -o test.out -c-array -ow 4  > LOG 2>&1
+if test $? -ne 1; then
+    cat LOG
+    fail
+fi
+diff test.ok LOG
+if test $? -ne 0; then fail; fi
+
+#
+# The things tested here, worked.
+# No other guarantees are made.
+#
+pass

--- a/test/02/t0272a.sh
+++ b/test/02/t0272a.sh
@@ -1,0 +1,226 @@
+#!/bin/sh
+#
+#       srecord - The "srecord" program.
+#       Copyright (C) 2007, 2008, 2011 Peter Miller
+#
+#       This program is free software; you can redistribute it and/or modify
+#       it under the terms of the GNU General Public License as published by
+#       the Free Software Foundation; either version 3 of the License, or
+#       (at your option) any later version.
+#
+#       This program is distributed in the hope that it will be useful,
+#       but WITHOUT ANY WARRANTY; without even the implied warranty of
+#       MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#       GNU General Public License for more details.
+#
+#       You should have received a copy of the GNU General Public License
+#       along with this program. If not, see
+#       <http://www.gnu.org/licenses/>.
+#
+
+TEST_SUBJECT="-c-array -output-word 64"
+. test_prelude.sh
+
+cat > test.in << 'fubar'
+S00600004844521B
+S111000748656C6C6F2C20576F726C64210A74
+S111002048656C6C6F2C20576F726C64210A5B
+S111004248656C6C6F2C20576F726C64210A39
+S5030003F9
+S9030007F5
+fubar
+if test $? -ne 0; then no_result; fi
+
+cat > test.ok << 'fubar'
+/* HDR */
+#include <stdint.h>
+const uint64_t eprom[] =
+{
+0x48FFFFFFFFFFFFFF, 0x6F57202C6F6C6C65, 0xFFFFFF0A21646C72,
+0x57202C6F6C6C6548, 0xFFFF0A21646C726F, 0x2C6F6C6C6548FFFF,
+0x0A21646C726F5720,
+};
+
+const unsigned long eprom_address[] =
+{
+0x00000000, 0x00000020, 0x00000040,
+};
+const unsigned long eprom_word_address[] =
+{
+0x00000000, 0x00000004, 0x00000008,
+};
+const unsigned long eprom_length_of_sections[] =
+{
+0x00000003, 0x00000002, 0x00000002,
+};
+const unsigned long eprom_sections    = 0x00000003;
+const unsigned long eprom_termination = 0x00000007;
+const unsigned long eprom_start       = 0x00000000;
+const unsigned long eprom_finish      = 0x00000050;
+const unsigned long eprom_length      = 0x00000050;
+
+#define EPROM_TERMINATION 0x00000007
+#define EPROM_START       0x00000000
+#define EPROM_FINISH      0x00000050
+#define EPROM_LENGTH      0x00000050
+#define EPROM_SECTIONS    0x00000003
+fubar
+if test $? -ne 0; then no_result; fi
+
+cat > test.ok.h << 'fubar'
+#ifndef TEST_H
+#define TEST_H
+#include <stdint.h>
+
+extern const unsigned long eprom_termination;
+extern const unsigned long eprom_start;
+extern const unsigned long eprom_finish;
+extern const unsigned long eprom_length;
+extern const unsigned long eprom_sections;
+extern const uint64_t eprom[];
+extern const unsigned long eprom_address[];
+extern const unsigned long eprom_word_address[];
+extern const unsigned long eprom_length_of_sections[];
+
+#endif /* TEST_H */
+fubar
+if test $? -ne 0; then no_result; fi
+
+srec_cat test.in -fill 0xFF -within test.in -range-padding=8 \
+    -o test.out -c-array -section-style -ow 8 -include
+if test $? -ne 0; then fail; fi
+
+diff test.ok test.out
+if test $? -ne 0; then fail; fi
+
+diff test.ok.h test.h
+if test $? -ne 0; then fail; fi
+
+# ---------- one more time, with decimal uint64_t words -----------------------
+
+cat > test.ok << 'fubar'
+/* HDR */
+#include <stdint.h>
+const uint64_t eprom[] =
+{
+5260204364768739327, 8022916636403854437, 18446743017707826290,
+6278066737626506568, 18446473737267868271, 3201897072895262719,
+729975031549876000,
+};
+
+const unsigned long eprom_address[] =
+{
+0, 32, 64,
+};
+const unsigned long eprom_word_address[] =
+{
+0, 4, 8,
+};
+const unsigned long eprom_length_of_sections[] =
+{
+3, 2, 2,
+};
+const unsigned long eprom_sections    = 3;
+const unsigned long eprom_termination = 7;
+const unsigned long eprom_start       = 0;
+const unsigned long eprom_finish      = 80;
+const unsigned long eprom_length      = 80;
+
+#define EPROM_TERMINATION 7
+#define EPROM_START       0
+#define EPROM_FINISH      80
+#define EPROM_LENGTH      80
+#define EPROM_SECTIONS    3
+fubar
+if test $? -ne 0; then no_result; fi
+
+srec_cat test.in -fill 0xFF -within test.in -range-padding=8 \
+    -o test.out -c-array -section-style -ow 8 -dec-style
+if test $? -ne 0; then fail; fi
+
+diff test.ok test.out
+if test $? -ne 0; then fail; fi
+
+# ---------- --output-word 8 is equivalent to -output-word 64 -----------------
+
+srec_cat test.in -fill 0xFF -within test.in -range-padding=8 \
+    -o test.out -c-array -section-style -ow 64 -dec-style
+if test $? -ne 0; then fail; fi
+
+diff test.ok test.out
+if test $? -ne 0; then fail; fi
+
+# ---------- one more time, with byte swapped input ---------------------------
+
+cat > test.ok << 'fubar'
+/* 00000007: HDR */
+#include <stdint.h>
+const uint64_t eprom[] =
+{
+0xFFFFFFFFFFFFFF48, 0x656C6C6F2C20576F, 0x726C64210AFFFFFF,
+0x48656C6C6F2C2057, 0x6F726C64210AFFFF, 0xFFFF48656C6C6F2C,
+0x20576F726C64210A,
+};
+
+const unsigned long eprom_address[] =
+{
+0x00000000, 0x00000020, 0x00000040,
+};
+const unsigned long eprom_word_address[] =
+{
+0x00000000, 0x00000004, 0x00000008,
+};
+const unsigned long eprom_length_of_sections[] =
+{
+0x00000003, 0x00000002, 0x00000002,
+};
+const unsigned long eprom_sections    = 0x00000003;
+const unsigned long eprom_termination = 0x00000000;
+const unsigned long eprom_start       = 0x00000000;
+const unsigned long eprom_finish      = 0x00000050;
+const unsigned long eprom_length      = 0x00000050;
+
+#define EPROM_TERMINATION 0x00000000
+#define EPROM_START       0x00000000
+#define EPROM_FINISH      0x00000050
+#define EPROM_LENGTH      0x00000050
+#define EPROM_SECTIONS    0x00000003
+fubar
+if test $? -ne 0; then no_result; fi
+
+srec_cat test.in -fill 0xFF -within test.in -range-padding=8 -byte-swap 8 \
+    -o test.out -c-array -section-style -ow 8
+if test $? -ne 0; then fail; fi
+
+diff test.ok test.out
+if test $? -ne 0; then fail; fi
+
+# ---------- Fatal alignment error --------------------------------------------
+cat > test.in << 'fubar'
+S0220000687474703A2F2F737265636F72642E736F75726365666F7267652E6E65742F1D
+S123000C000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1FE0
+S123002C202122232425262728292A2B2C2D2E2F303132333435363738393A3B3C3D3E3FC0
+S5030002FA
+S903000CF0
+fubar
+if test $? -ne 0; then no_result; fi
+
+cat > test.ok << 'fubar'
+srec_cat: test.out: 5: The C-Array (uint64_t) output format uses 8-byte
+    alignment, but unaligned data is present. Use a "--fill 0xNN --within
+    <input> --range-padding 8" filter to fix this problem.
+fubar
+
+srec_cat test.in  -o test.out -c-array -ow 8  > LOG 2>&1
+if test $? -ne 1; then
+    cat LOG
+    fail
+fi
+diff test.ok LOG
+if test $? -ne 0; then fail; fi
+
+#
+# The things tested here, worked.
+# No other guarantees are made.
+#
+pass

--- a/test/hyphen/main.cc
+++ b/test/hyphen/main.cc
@@ -17,6 +17,7 @@
 //
 
 #include <cstdio>
+#include <cstdint>
 #include <cstdlib>
 #include <getopt.h>
 #include <string>

--- a/test/url_decode/main.cc
+++ b/test/url_decode/main.cc
@@ -17,6 +17,7 @@
 //
 
 #include <cctype>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>


### PR DESCRIPTION
I have a use case where I want to use `srec_cat` to convert a .bin into a C array of `uint32_t`.

This patch supports that use case, and adds support for generating `uint16_t` and `uint64_t` arrays, while staying backwards compatible with previous behavior if `-output-word` is given no argument.