### PR TITLE
fix build failure with gcc 15 by adding cstdint header

### DIFF
--- a/srecord/input/file/hp64k.h
+++ b/srecord/input/file/hp64k.h
@@ -21,6 +21,7 @@
 #define LIB_INPUT_FILE_HP64K
 
 #include <srecord/input/file.h>
+#include <cstdint>
 
 namespace srecord {
 


### PR DESCRIPTION
Fixes #79

```
srecord/input/file/hp64k.h:82:21: error: ‘uint16_t’ has not been declared
   82 |     bool read_u16be(uint16_t *dest);
      |                     ^~~~~~~~
/home/abuild/rpmbuild/BUILD/srecord-1.65.0-build/srecord-1.65.0-Source/./srecord/input/file/hp64k.h:1:1: note: ‘uint16_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
  +++ |+#include <cstdint>
    1 | //
make[2]: *** [srecord/CMakeFiles/lib_srecord.dir/build.make:222: srecord/CMakeFiles/lib_srecord.dir/arglex/tool/input.cc.o] Error 1
```

    * From gcc 13, cstdint header must be explicitly included for uint_X data types.
    * See also: https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes