### PR TITLE
gcc 13+ fixes 

### DIFF
--- a/srec_cat/main.cc
+++ b/srec_cat/main.cc
@@ -17,6 +17,7 @@
 //
 
 #include <iostream>
+#include <cstdint>
 #include <cstdlib>
 
 #include <srecord/input/catenate.h>

--- a/srecord/arglex.cc
+++ b/srecord/arglex.cc
@@ -19,6 +19,7 @@
 #include <cassert>
 #include <cctype>
 #include <cerrno>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>

--- a/srecord/arglex/abbreviate.cc
+++ b/srecord/arglex/abbreviate.cc
@@ -16,6 +16,8 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //
 
+#include <cstdint>
+
 #include <srecord/arglex.h>
 
 

--- a/srecord/input/file.h
+++ b/srecord/input/file.h
@@ -19,6 +19,7 @@
 #ifndef SRECORD_INPUT_FILE_H
 #define SRECORD_INPUT_FILE_H
 
+#include <cstdint>
 #include <string>
 
 #include <srecord/input.h>

--- a/srecord/input/filter/sequence.h
+++ b/srecord/input/filter/sequence.h
@@ -20,6 +20,8 @@
 #ifndef SRECORD_INPUT_FILTER_SEQUENCE_H
 #define SRECORD_INPUT_FILTER_SEQUENCE_H
 
+#include <cstdint>
+
 #include <srecord/input/filter.h>
 
 namespace srecord

--- a/srecord/memory.h
+++ b/srecord/memory.h
@@ -20,6 +20,7 @@
 #ifndef SRECORD_MEMORY_H
 #define SRECORD_MEMORY_H
 
+#include <cstdint>
 #include <string>
 
 #include <srecord/defcon.h>

--- a/srecord/memory/walker.h
+++ b/srecord/memory/walker.h
@@ -20,6 +20,7 @@
 #ifndef SRECORD_MEMORY_WALKER_H
 #define SRECORD_MEMORY_WALKER_H
 
+#include <cstdint>
 #include <memory>
 
 namespace srecord {

--- a/srecord/output.h
+++ b/srecord/output.h
@@ -20,6 +20,7 @@
 #define SRECORD_OUTPUT_H
 
 #include <cstdarg>
+#include <cstdint>
 #include <string>
 #include <memory>
 

--- a/srecord/pretty_size.h
+++ b/srecord/pretty_size.h
@@ -20,6 +20,7 @@
 #ifndef SRECORD_PRETTY_SIZE_H
 #define SRECORD_PRETTY_SIZE_H
 
+#include <cstdint>
 #include <string>
 
 namespace srecord

--- a/srecord/quit/normal.cc
+++ b/srecord/quit/normal.cc
@@ -17,6 +17,7 @@
 //
 
 #include <cstdarg>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>

--- a/srecord/string/quote_c.cc
+++ b/srecord/string/quote_c.cc
@@ -16,6 +16,8 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //
 
+#include <cstdint>
+
 #include <srecord/string.h>
 
 

--- a/srecord/string/url_decode.cc
+++ b/srecord/string/url_decode.cc
@@ -16,6 +16,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //
 
+#include <cstdint>
 #include <sstream>
 
 #include <srecord/string.h>

--- a/srecord/string/url_encode.cc
+++ b/srecord/string/url_encode.cc
@@ -17,6 +17,7 @@
 //
 
 #include <sstream>
+#include <cstdint>
 #include <cstring>
 
 #include <srecord/string.h>

--- a/test/hyphen/main.cc
+++ b/test/hyphen/main.cc
@@ -16,6 +16,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //
 
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <getopt.h>

--- a/test/url_decode/main.cc
+++ b/test/url_decode/main.cc
@@ -17,6 +17,7 @@
 //
 
 #include <cctype>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>


### PR DESCRIPTION
As gcc has removed implicit inclusion for cstdint in version 13 and above, this needs to be manually included.

https://gcc.gnu.org/gcc-13/porting_to.html